### PR TITLE
Optimize CI Pipeline to reduce runtime

### DIFF
--- a/.github/workflows/rad_sim_ci.yml
+++ b/.github/workflows/rad_sim_ci.yml
@@ -1,5 +1,8 @@
 name: RAD-Sim CI
 
+env:
+  SYSTEMC_VERSION: "2.3.4"
+
 on:
   push:
     branches: [ "main" ]
@@ -18,8 +21,15 @@ jobs:
     - name: Set time
       run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
 
+    - name: Cache SystemC build files
+      id: cache-systemc
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/work/rad-flow/rad-flow/systemc-${{ env.SYSTEMC_VERSION }}/build
+        key: ubuntu-64-systemc-${{ env.SYSTEMC_VERSION }}
+
     - name: Setup SystemC
-      run: ./scripts/setup_system_c.sh
+      run: ./scripts/setup_system_c.sh -v ${{ env.SYSTEMC_VERSION }}
 
     - name: Setup Mambaforge (Conda)
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/rad_sim_ci.yml
+++ b/.github/workflows/rad_sim_ci.yml
@@ -14,25 +14,43 @@ jobs:
         shell: bash -el {0}
     steps:
     - uses: actions/checkout@v3
-    - name: setup systemc
+
+    - name: Set time
+      run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+    - name: Setup SystemC
       run: ./scripts/setup_system_c.sh
+
     - name: Setup Mambaforge (Conda)
       uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
         activate-environment: radflow
-        environment-file: rad-flow-env.yml
         use-mamba: true
-    - name: build rad-sim
+
+    - name: Cache Conda ENV
+      id: cache-conda
+      uses: actions/cache@v3
+      with:
+        path: /usr/share/miniconda3/envs/radflow
+        key: ubuntu-64-conda-${{ hashFiles('rad-flow-env.yml') }}
+
+    - name: Update Conda ENV
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: mamba env update -n radflow -f rad-flow-env.yml
+
+    - name: Build RAD-Sim
       run: |
         cd rad-sim
         python config.py mlp
-    - name: generate test cases
+    
+    - name: Generate Test Cases
       run: |
         cd rad-sim/example-designs/mlp/compiler
         python gen_testcase.py 4 512 512 512 256 128 4 3 2 2
-    - name: run tests
+
+    - name: Run Tests
       run: |
         cd rad-sim/build
         make run

--- a/.github/workflows/rad_sim_ci.yml
+++ b/.github/workflows/rad_sim_ci.yml
@@ -16,12 +16,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: setup systemc
       run: ./scripts/setup_system_c.sh
-    - name: setup anaconda env
+    - name: Setup Mambaforge (Conda)
       uses: conda-incubator/setup-miniconda@v2
       with:
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
         activate-environment: radflow
         environment-file: rad-flow-env.yml
-        python-version: 3.8
+        use-mamba: true
     - name: build rad-sim
       run: |
         cd rad-sim

--- a/scripts/setup_system_c.sh
+++ b/scripts/setup_system_c.sh
@@ -1,12 +1,31 @@
 #!/bin/bash
+usage()
+{
+   echo ""
+   echo "Usage: $0 -v version"
+   echo -e "\t-v The SystemC version to setup (default: 2.3.4)"
+}
+
+while getopts "v:h" opt
+do
+   case "$opt" in
+      v) SYSTEMC_VERSION="$OPTARG" ;;
+      h) usage
+         exit 0
+         ;;
+      *) usage
+         exit 1
+         ;;
+   esac
+done
+
+if [ -z "${SYSTEMC_VERSION}" ]; then
+    usage
+    exit 1
+fi
 
 sudo apt-get update && apt-get upgrade -y
 sudo apt install build-essential cmake
-
-# SYSTEMC
-
-# Set variables for SystemC
-SYSTEMC_VERSION="2.3.4"
 
 wget -O systemc-$SYSTEMC_VERSION.tar.gz https://github.com/accellera-official/systemc/archive/refs/tags/$SYSTEMC_VERSION.tar.gz
 tar xzf systemc-$SYSTEMC_VERSION.tar.gz


### PR DESCRIPTION
Implemented 3 CI optimizations:
1) Replaced miniconda with mambaforge
2) Cached conda libraries
3) Cached SystemC build files

Reduced runtime by ~3x