### PR TITLE
Downgraded cmake required version from 3.19 to 3.16, works on add+mlp

### DIFF
--- a/rad-sim/CMakeLists.txt
+++ b/rad-sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 17)
 project(RADSim)
 

--- a/rad-sim/example-designs/CMakeLists.txt
+++ b/rad-sim/example-designs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 add_subdirectory(${DESIGN})

--- a/rad-sim/example-designs/add/CMakeLists.txt
+++ b/rad-sim/example-designs/add/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/example-designs/aximm_hello_world/CMakeLists.txt
+++ b/rad-sim/example-designs/aximm_hello_world/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/example-designs/dlrm/CMakeLists.txt
+++ b/rad-sim/example-designs/dlrm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/example-designs/mlp/CMakeLists.txt
+++ b/rad-sim/example-designs/mlp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/example-designs/npu/CMakeLists.txt
+++ b/rad-sim/example-designs/npu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/example-designs/rtl_add/CMakeLists.txt
+++ b/rad-sim/example-designs/rtl_add/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 add_subdirectory(modules/rtl)

--- a/rad-sim/example-designs/rtl_add/modules/rtl/CMakeLists.txt
+++ b/rad-sim/example-designs/rtl_add/modules/rtl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 
 find_package(verilator HINTS $ENV{VERILATOR_ROOT})
 if (NOT verilator_FOUND)

--- a/rad-sim/sim/CMakeLists.txt
+++ b/rad-sim/sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 

--- a/rad-sim/sim/dram/CMakeLists.txt
+++ b/rad-sim/sim/dram/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 add_subdirectory(DRAMsim3)

--- a/rad-sim/sim/dram/DRAMsim3/CMakeLists.txt
+++ b/rad-sim/sim/dram/DRAMsim3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/sim/noc/CMakeLists.txt
+++ b/rad-sim/sim/noc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 add_subdirectory(booksim)

--- a/rad-sim/sim/noc/booksim/CMakeLists.txt
+++ b/rad-sim/sim/noc/booksim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/test/CMakeLists.txt
+++ b/rad-sim/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(

--- a/rad-sim/test_legacy/CMakeLists.txt
+++ b/rad-sim/test_legacy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 find_package(SystemCLanguage CONFIG REQUIRED)
 
 include_directories(


### PR DESCRIPTION
Downgraded cmake required version from 3.19 to 3.16, works on add and mlp example designs