### PR TITLE
RAD-Sim Design Correctness Reporting

### DIFF
--- a/rad-sim/config.py
+++ b/rad-sim/config.py
@@ -294,7 +294,7 @@ def generate_radsim_main(design_name):
     main_cpp_file.write("\tsim_trace_probe.dump_traces();\n")
     main_cpp_file.write("\t(void)argc;\n")
     main_cpp_file.write("\t(void)argv;\n")
-    main_cpp_file.write("\treturn 0;\n")
+    main_cpp_file.write("\treturn radsim_design.GetDesignResult();\n")
     main_cpp_file.write("}\n")
 
 def prepare_build_dir(design_name):

--- a/rad-sim/config.py
+++ b/rad-sim/config.py
@@ -294,7 +294,7 @@ def generate_radsim_main(design_name):
     main_cpp_file.write("\tsim_trace_probe.dump_traces();\n")
     main_cpp_file.write("\t(void)argc;\n")
     main_cpp_file.write("\t(void)argv;\n")
-    main_cpp_file.write("\treturn radsim_design.GetDesignResult();\n")
+    main_cpp_file.write("\treturn radsim_design.GetDesignExitCode();\n")
     main_cpp_file.write("}\n")
 
 def prepare_build_dir(design_name):

--- a/rad-sim/config.py
+++ b/rad-sim/config.py
@@ -294,7 +294,7 @@ def generate_radsim_main(design_name):
     main_cpp_file.write("\tsim_trace_probe.dump_traces();\n")
     main_cpp_file.write("\t(void)argc;\n")
     main_cpp_file.write("\t(void)argv;\n")
-    main_cpp_file.write("\treturn radsim_design.GetDesignExitCode();\n")
+    main_cpp_file.write("\treturn radsim_design.GetSimExitCode();\n")
     main_cpp_file.write("}\n")
 
 def prepare_build_dir(design_name):

--- a/rad-sim/example-designs/add/add_driver.cpp
+++ b/rad-sim/example-designs/add/add_driver.cpp
@@ -58,8 +58,12 @@ void add_driver::sink() {
   //std::cout << "Received " << response.read().to_uint64() << " sum from the adder!" << std::endl;
   //std::cout << "The actual sum is " << actual_sum << std::endl;
 
-  if (response.read() != actual_sum) std::cout << "FAILURE - Output is not matching!" << std::endl;
-  else std::cout << "SUCCESS - Output is matching!" << std::endl;
+  if (response.read() != actual_sum) {
+    std::cout << "FAILURE - Output is not matching!" << std::endl;
+    radsim_design.ReportDesignFailure();
+  } else {
+    std::cout << "SUCCESS - Output is matching!" << std::endl;
+  }
 
   end_cycle = GetSimulationCycle(1.0);
   end_time = std::chrono::steady_clock::now();

--- a/rad-sim/example-designs/dlrm/dlrm_driver.cpp
+++ b/rad-sim/example-designs/dlrm/dlrm_driver.cpp
@@ -194,8 +194,8 @@ void dlrm_driver::sink() {
   if (all_outputs_matching) {
     std::cout << "Simulation PASSED! All outputs matching!" << std::endl;
   } else {
-    std::cout << "Simulation FAILED! Some outputs are NOT matching!"
-              << std::endl;
+    std::cout << "Simulation FAILED! Some outputs are NOT matching!" << std::endl;
+    radsim_design.ReportDesignFailure();
   }
   _end_cycle =
       GetSimulationCycle(radsim_config.GetDoubleKnob("sim_driver_period"));

--- a/rad-sim/example-designs/mlp/mlp_driver.cpp
+++ b/rad-sim/example-designs/mlp/mlp_driver.cpp
@@ -126,7 +126,10 @@ void mlp_driver::sink() {
     }
     wait();
   }
-  if (mistake) std::cout << "FAILURE - Some outputs NOT matching!" << std::endl;
+  if (mistake) {
+    std::cout << "FAILURE - Some outputs NOT matching!" << std::endl;
+    radsim_design.ReportDesignFailure();
+  }
   else std::cout << "SUCCESS - All outputs are matching!" << std::endl;
 
   end_cycle = GetSimulationCycle(1.0);

--- a/rad-sim/example-designs/mlp_int8/mlp_driver.cpp
+++ b/rad-sim/example-designs/mlp_int8/mlp_driver.cpp
@@ -290,7 +290,7 @@ void mlp_driver::source() {
 
 void mlp_driver::sink() {
   unsigned int read_outputs = 0;
-  bool mistake = false;
+  bool mistake = true;
 
   data_vector<sc_int<IPRECISION>> output_vec;
   while (read_outputs < golden_outputs.size()) {
@@ -307,14 +307,19 @@ void mlp_driver::sink() {
     }
     wait();
   }
-  if (mistake) std::cout << "FAILURE - Some outputs NOT matching!" << std::endl;
-  else std::cout << "SUCCESS - All outputs are matching!" << std::endl;
+  if (mistake) {
+    std::cout << "FAILURE - Some outputs NOT matching!" << std::endl;
+    radsim_design.ReportDesignFailure();
+  } else {
+    std::cout << "SUCCESS - All outputs are matching!" << std::endl;
+  }
 
   end_cycle = GetSimulationCycle(1.0);
   end_time = std::chrono::steady_clock::now();
   std::cout << "Simulation Cycles = " << end_cycle - start_cycle << std::endl;
   std::cout << "Simulation Time = " << std::chrono::duration_cast<std::chrono::milliseconds> (end_time - start_time).count() << " ms" << std::endl;
   NoCTransactionTelemetry::DumpStatsToFile("stats.csv");
+  NoCFlitTelemetry::DumpNoCFlitTracesToFile("flit_traces.csv");
 
   std::vector<double> aggregate_bandwidths = NoCTransactionTelemetry::DumpTrafficFlows("traffic_flows", 
     end_cycle - start_cycle, radsim_design.GetNodeModuleNames());

--- a/rad-sim/example-designs/mlp_int8/mlp_driver.cpp
+++ b/rad-sim/example-designs/mlp_int8/mlp_driver.cpp
@@ -290,7 +290,7 @@ void mlp_driver::source() {
 
 void mlp_driver::sink() {
   unsigned int read_outputs = 0;
-  bool mistake = true;
+  bool mistake = false;
 
   data_vector<sc_int<IPRECISION>> output_vec;
   while (read_outputs < golden_outputs.size()) {

--- a/rad-sim/example-designs/rtl_add/rtl_add_driver.cpp
+++ b/rad-sim/example-designs/rtl_add/rtl_add_driver.cpp
@@ -58,8 +58,12 @@ void rtl_add_driver::sink() {
   //std::cout << "Received " << response.read().to_uint64() << " sum from the adder!" << std::endl;
   //std::cout << "The actual sum is " << actual_sum << std::endl;
 
-  if (response.read() != actual_sum) std::cout << "FAILURE - Output is not matching!" << std::endl;
-  else std::cout << "SUCCESS - Output is matching!" << std::endl;
+  if (response.read() != actual_sum) {
+    std::cout << "FAILURE - Output is not matching!" << std::endl;
+    radsim_design.ReportDesignFailure();
+  } else {
+    std::cout << "SUCCESS - Output is matching!" << std::endl;
+  }
 
   end_cycle = GetSimulationCycle(1.0);
   end_time = std::chrono::steady_clock::now();

--- a/rad-sim/sim/design_context.cpp
+++ b/rad-sim/sim/design_context.cpp
@@ -689,3 +689,11 @@ uint64_t RADSimDesignContext::GetPortBaseAddress(std::string &port_name) {
          _aximm_port_base_addresses.end());
   return _aximm_port_base_addresses[port_name];
 }
+
+int RADSimDesignContext::GetDesignResult() {
+  return _design_result;
+}
+
+void RADSimDesignContext::ReportDesignFailure() {
+  _design_result = 1;
+}

--- a/rad-sim/sim/design_context.cpp
+++ b/rad-sim/sim/design_context.cpp
@@ -690,7 +690,7 @@ uint64_t RADSimDesignContext::GetPortBaseAddress(std::string &port_name) {
   return _aximm_port_base_addresses[port_name];
 }
 
-int RADSimDesignContext::GetDesignExitCode() {
+int RADSimDesignContext::GetSimExitCode() {
   return _sim_exit_code;
 }
 

--- a/rad-sim/sim/design_context.cpp
+++ b/rad-sim/sim/design_context.cpp
@@ -690,10 +690,10 @@ uint64_t RADSimDesignContext::GetPortBaseAddress(std::string &port_name) {
   return _aximm_port_base_addresses[port_name];
 }
 
-int RADSimDesignContext::GetDesignResult() {
-  return _design_result;
+int RADSimDesignContext::GetDesignExitCode() {
+  return _sim_exit_code;
 }
 
 void RADSimDesignContext::ReportDesignFailure() {
-  _design_result = 1;
+  _sim_exit_code = 1;
 }

--- a/rad-sim/sim/design_context.hpp
+++ b/rad-sim/sim/design_context.hpp
@@ -12,6 +12,8 @@
 
 class RADSimDesignContext {
 private:
+  int _design_result = 0;
+
   std::vector<sc_clock *> _noc_clks;
   std::vector<sc_clock *> _adapter_clks;
   std::vector<sc_clock *> _module_clks;
@@ -96,6 +98,9 @@ public:
   void DumpDesignContext();
   std::vector<std::vector<std::set<std::string>>> &GetNodeModuleNames();
   uint64_t GetPortBaseAddress(std::string &port_name);
+
+  int GetDesignResult();
+  void ReportDesignFailure();
 };
 
 extern RADSimDesignContext radsim_design;

--- a/rad-sim/sim/design_context.hpp
+++ b/rad-sim/sim/design_context.hpp
@@ -99,7 +99,7 @@ public:
   std::vector<std::vector<std::set<std::string>>> &GetNodeModuleNames();
   uint64_t GetPortBaseAddress(std::string &port_name);
 
-  int GetDesignExitCode();
+  int GetSimExitCode();
   void ReportDesignFailure();
 };
 

--- a/rad-sim/sim/design_context.hpp
+++ b/rad-sim/sim/design_context.hpp
@@ -12,7 +12,7 @@
 
 class RADSimDesignContext {
 private:
-  int _design_result = 0;
+  int _sim_exit_code = 0;
 
   std::vector<sc_clock *> _noc_clks;
   std::vector<sc_clock *> _adapter_clks;
@@ -99,7 +99,7 @@ public:
   std::vector<std::vector<std::set<std::string>>> &GetNodeModuleNames();
   uint64_t GetPortBaseAddress(std::string &port_name);
 
-  int GetDesignResult();
+  int GetDesignExitCode();
   void ReportDesignFailure();
 };
 

--- a/rad-sim/sim/main.cpp
+++ b/rad-sim/sim/main.cpp
@@ -38,5 +38,5 @@ int sc_main(int argc, char *argv[]) {
 	sim_trace_probe.dump_traces();
 	(void)argc;
 	(void)argv;
-	return 0;
+	return radsim_design.GetDesignResult();
 }

--- a/rad-sim/sim/main.cpp
+++ b/rad-sim/sim/main.cpp
@@ -38,5 +38,5 @@ int sc_main(int argc, char *argv[]) {
 	sim_trace_probe.dump_traces();
 	(void)argc;
 	(void)argv;
-	return radsim_design.GetDesignResult();
+	return radsim_design.GetDesignExitCode();
 }

--- a/rad-sim/sim/main.cpp
+++ b/rad-sim/sim/main.cpp
@@ -38,5 +38,5 @@ int sc_main(int argc, char *argv[]) {
 	sim_trace_probe.dump_traces();
 	(void)argc;
 	(void)argv;
-	return radsim_design.GetDesignExitCode();
+	return radsim_design.GetSimExitCode();
 }


### PR DESCRIPTION
Introduces the `ReportDesignFailure()` function in the RAD-Sim Design Context to report a design failure (i.e. when the design fails the test bench).
This is an optional call, if the function is not called, success is assumed and the original behaviour is preserved.
The design failure is returned as an exit code from the `sc_main` function.

This PR is a branch of the `dev-gtrieu` branch to observe the correct diffs. Please merge #21 before this, and change the base to `main`.
