### PR TITLE
RTL AXI-MM Support and Example Design

### DIFF
--- a/docs/rad-sim-rtl-code.rst
+++ b/docs/rad-sim-rtl-code.rst
@@ -3,6 +3,7 @@ Compiling a RAD-Sim Module with RTL
 RAD-Sim has the capability to support RTL code (Verilog/SystemVerilog only) through Verilator.
 Verilator compiles RTL code into a faster optimized model, wrapped inside a C++/SystemC module.
 More information about Verilator can be found at `Veripool <https://veripool.org/guide/latest/index.html>`_.
+A performance test repo can be found at `GitHub https://github.com/geotrieu/mvm_perf_test`.
 
 Installation
 -------------

--- a/docs/rad-sim-rtl-code.rst
+++ b/docs/rad-sim-rtl-code.rst
@@ -106,9 +106,9 @@ Automatic wrapper generation follows the workflow:
 These scripts produce basic source and header wrapper files for the specified RTL modules.
 Advanced users may edit these files to add additional functionality.
 
-AXI-S Formatting Requirement
+AXI-S/AXI-MM Formatting Requirement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Ports in RTL modules using AXI-S must be specified in the format ``axis_{name}_{signal}`` to be recognized by the port mappings script.
+Ports in RTL modules using AXI-S/AXI-MM must be specified in the format ``axis_{name}_{signal}`` or ``aximm_{name}_{signal}`` to be recognized by the port mappings script.
 
 Port Map File Format
 ^^^^^^^^^^^^^^^^^^^^^
@@ -118,6 +118,7 @@ The port map file is a blank-space delimited file used to specify the connection
 * Modules are defined by ``module {name}``.
 * Input and Output ports are defined by ``{input/output} {port_width} {rtl_port} {radsim_port}``.
 * AXI-S ports are defined by ``axis {master/slave} {rtl_port} {axis_interface} {axis_port}``.
+* AXI-MM ports are defined by ``aximm {master/slave} {rtl_port} {aximm_interface} {aximm_port}``.
 
 An example port map file from the ``rtl_add`` example is shown below:
 

--- a/rad-sim/example-designs/mlp_int8/modules/rtl_mvm.cpp
+++ b/rad-sim/example-designs/mlp_int8/modules/rtl_mvm.cpp
@@ -2,7 +2,7 @@
 
 rtl_mvm::rtl_mvm(const sc_module_name &name) : RADSimModule(name) {
 	char vrtl_mvm_name[25];
-	std::string vrtl_mvm_name_str = std::string(name) + "_vmvm";
+	std::string vrtl_mvm_name_str = std::string(name);
 	std::strcpy(vrtl_mvm_name, vrtl_mvm_name_str.c_str());
 
 	vrtl_mvm = new Vrtl_mvm{vrtl_mvm_name};

--- a/rad-sim/example-designs/rtl_add/modules/adder.cpp
+++ b/rad-sim/example-designs/rtl_add/modules/adder.cpp
@@ -2,7 +2,7 @@
 
 adder::adder(const sc_module_name &name) : RADSimModule(name) {
 	char vadder_name[25];
-	std::string vadder_name_str = std::string(name) + "_vmvm";
+	std::string vadder_name_str = std::string(name);
 	std::strcpy(vadder_name, vadder_name_str.c_str());
 
 	vadder = new Vadder{vadder_name};

--- a/rad-sim/example-designs/rtl_add/modules/client.cpp
+++ b/rad-sim/example-designs/rtl_add/modules/client.cpp
@@ -2,7 +2,7 @@
 
 client::client(const sc_module_name &name) : RADSimModule(name) {
 	char vclient_name[25];
-	std::string vclient_name_str = std::string(name) + "_vmvm";
+	std::string vclient_name_str = std::string(name);
 	std::strcpy(vclient_name, vclient_name_str.c_str());
 
 	vclient = new Vclient{vclient_name};

--- a/rad-sim/example-designs/rtl_aximm/CMakeLists.txt
+++ b/rad-sim/example-designs/rtl_aximm/CMakeLists.txt
@@ -16,20 +16,22 @@ include_directories(
 include_directories(SYSTEM "${VERILATOR_ROOT}/include")
 
 set(srcfiles
-  modules/adder.cpp
   modules/client.cpp
-  rtl_add_top.cpp
-  rtl_add_driver.cpp
-  rtl_add_system.cpp
+  modules/server.cpp
+  rtl_aximm_top.cpp
+  rtl_aximm_driver.cpp
+  rtl_aximm_system.cpp
 )
 
 set(hdrfiles
-  modules/adder.hpp
   modules/client.hpp
-  rtl_add_top.hpp
-  rtl_add_driver.hpp
-  rtl_add_system.hpp
+  modules/server.hpp
+  rtl_aximm_top.hpp
+  rtl_aximm_driver.hpp
+  rtl_aximm_system.hpp
 )
+
+add_compile_options(-Wall -Wextra -pedantic)
 
 add_library(design STATIC ${srcfiles} ${hdrfiles})
 target_link_libraries(design PUBLIC SystemC::systemc booksim noc rtl_designs)

--- a/rad-sim/example-designs/rtl_aximm/config.yml
+++ b/rad-sim/example-designs/rtl_aximm/config.yml
@@ -1,0 +1,37 @@
+noc:
+  type: ['2d']
+  num_nocs: 1
+  clk_period: [1.0]
+  payload_width: [166]
+  topology: ['mesh']
+  dim_x: [4]
+  dim_y: [4] 
+  routing_func: ['dim_order']
+  vcs: [5]
+  vc_buffer_size: [8]
+  output_buffer_size: [8]
+  num_packet_types: [5]
+  router_uarch: ['iq']
+  vc_allocator: ['islip']
+  sw_allocator:  ['islip']
+  credit_delay: [1]
+  routing_delay: [1]
+  vc_alloc_delay: [1]
+  sw_alloc_delay: [1]
+
+noc_adapters:
+  clk_period: [1.25]
+  fifo_size: [16]
+  obuff_size: [2]
+  in_arbiter: ['fixed_rr']
+  out_arbiter: ['priority_rr']
+  vc_mapping: ['direct']
+
+design:
+  name: 'rtl_aximm'
+  noc_placement: ['rtl_aximm.place']
+  clk_periods: [5.0]
+
+telemetry:
+  log_verbosity: 2
+  traces: []

--- a/rad-sim/example-designs/rtl_aximm/modules/client.cpp
+++ b/rad-sim/example-designs/rtl_aximm/modules/client.cpp
@@ -1,0 +1,69 @@
+#include <client.hpp>
+
+client::client(const sc_module_name &name) : RADSimModule(name) {
+	char vclient_name[25];
+	std::string vclient_name_str = std::string(name);
+	std::strcpy(vclient_name, vclient_name_str.c_str());
+
+	vclient = new Vclient{vclient_name};
+	vclient->clk(clk);
+	vclient->rst(rst);
+	vclient->start_sig(start_sig);
+	vclient->start_rdy(start_rdy);
+	vclient->output_valid(output_valid);
+	vclient->output_result(output_result);
+	vclient->output_rdy(output_rdy);
+	vclient->aximm_client_awvalid(aximm_client.awvalid);
+	vclient->aximm_client_awready(aximm_client.awready);
+	vclient->aximm_client_awid(aximm_client.awid);
+	vclient->aximm_client_awaddr(aximm_client.awaddr);
+	vclient->aximm_client_awlen(aximm_client.awlen);
+	vclient->aximm_client_awsize(aximm_client.awsize);
+	vclient->aximm_client_awburst(aximm_client.awburst);
+	vclient->aximm_client_awuser(aximm_client.awuser);
+	vclient->aximm_client_wvalid(aximm_client.wvalid);
+	vclient->aximm_client_wready(aximm_client.wready);
+	vclient->aximm_client_wid(aximm_client.wid);
+	vclient->aximm_client_wdata(aximm_client.wdata);
+	vclient->aximm_client_wlast(aximm_client.wlast);
+	vclient->aximm_client_wuser(aximm_client.wuser);
+	vclient->aximm_client_bvalid(aximm_client.bvalid);
+	vclient->aximm_client_bready(aximm_client.bready);
+	vclient->aximm_client_bid(aximm_client.bid);
+	vclient->aximm_client_bresp(aximm_client.bresp);
+	vclient->aximm_client_buser(aximm_client.buser);
+	vclient->aximm_client_arvalid(aximm_client.arvalid);
+	vclient->aximm_client_arready(aximm_client.arready);
+	vclient->aximm_client_arid(aximm_client.arid);
+	vclient->aximm_client_araddr(aximm_client.araddr);
+	vclient->aximm_client_arlen(aximm_client.arlen);
+	vclient->aximm_client_arsize(aximm_client.arsize);
+	vclient->aximm_client_arburst(aximm_client.arburst);
+	vclient->aximm_client_aruser(aximm_client.aruser);
+	vclient->aximm_client_rvalid(aximm_client.rvalid);
+	vclient->aximm_client_rready(aximm_client.rready);
+	vclient->aximm_client_rid(aximm_client.rid);
+	vclient->aximm_client_rdata(aximm_client.rdata);
+	vclient->aximm_client_rresp(aximm_client.rresp);
+	vclient->aximm_client_rlast(aximm_client.rlast);
+	vclient->aximm_client_ruser(aximm_client.ruser);
+
+	this->RegisterModuleInfo();
+}
+
+client::~client() {
+	vclient->final();
+	delete vclient;
+}
+
+void client::RegisterModuleInfo() {
+	std::string port_name;
+	_num_noc_axis_slave_ports = 0;
+	_num_noc_axis_master_ports = 0;
+	_num_noc_aximm_slave_ports = 0;
+	_num_noc_aximm_master_ports = 0;
+
+	port_name = module_name + ".aximm_client";
+	RegisterAximmMasterPort(port_name, &aximm_client, 512);
+
+}

--- a/rad-sim/example-designs/rtl_aximm/modules/client.hpp
+++ b/rad-sim/example-designs/rtl_aximm/modules/client.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <aximm_interface.hpp>
+#include <design_context.hpp>
+#include <radsim_defines.hpp>
+#include <radsim_module.hpp>
+#include <string>
+#include <systemc.h>
+#include <vector>
+
+#include <Vclient.h>
+class client : public RADSimModule {
+private:
+	Vclient* vclient;
+
+public:
+	sc_in<bool> rst;
+	sc_in<bool> start_sig;
+	sc_out<bool> start_rdy;
+	sc_out<bool> output_valid;
+	sc_out<bool> output_result;
+	sc_in<bool> output_rdy;
+
+	aximm_master_port aximm_client;
+
+	client(const sc_module_name &name);
+	~client();
+
+	SC_HAS_PROCESS(client);
+	void RegisterModuleInfo();
+};

--- a/rad-sim/example-designs/rtl_aximm/modules/rtl/CMakeLists.txt
+++ b/rad-sim/example-designs/rtl_aximm/modules/rtl/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+
+find_package(verilator HINTS $ENV{VERILATOR_ROOT})
+if (NOT verilator_FOUND)
+  message(FATAL_ERROR "Verilator was not found. Either install it, or set the VERILATOR_ROOT environment variable")
+endif()
+find_package(SystemCLanguage CONFIG REQUIRED)
+
+set(verilator_options --pins-bv 2 -Wno-fatal -Wall)
+
+set(rtl_top_modules
+  client.sv
+  server.sv
+)
+
+set(rtl_libraries
+  memory.sv
+)
+
+add_library(rtl_designs STATIC)
+target_link_libraries(rtl_designs PUBLIC SystemC::systemc)
+
+foreach(module IN LISTS rtl_top_modules)
+  foreach(rtl_library IN LISTS rtl_libraries)
+    list(APPEND VERILOG_LIBRARIES "-v")
+    list(APPEND VERILOG_LIBRARIES ${rtl_library})
+  endforeach()
+
+  verilate(rtl_designs
+    SOURCES ${module}
+    SYSTEMC
+    VERILATOR_ARGS ${verilator_options} ${VERILOG_LIBRARIES}
+  )
+endforeach()

--- a/rad-sim/example-designs/rtl_aximm/modules/rtl/client.sv
+++ b/rad-sim/example-designs/rtl_aximm/modules/rtl/client.sv
@@ -1,0 +1,204 @@
+module client # (
+    parameter DATA = 64'hDEADBEEF,
+    parameter DST_MEM_ADDR = 3,
+    parameter DST_NODE = 64'h2,
+    parameter SRC_NODE = 64'h0,
+    parameter AXI4_IDW = 8,
+    parameter AXI4_ADDRW = 64,
+    parameter AXI4_LENW = 8,
+    parameter AXI4_SIZEW = 3,
+    parameter AXI4_BURSTW = 2,
+    parameter AXI4_USERW = 64,
+    parameter AXI4_MAX_DATAW = 512,
+    parameter AXI4_RESPW = 2
+) (
+	input clk,
+    input rst,
+    input start_sig,
+    output logic start_rdy,
+    output logic output_valid,
+    output logic output_result,
+    input output_rdy,
+    // AXI-MM Address Write Channel
+    output logic aximm_client_awvalid,
+    input aximm_client_awready,
+    output logic [AXI4_IDW-1:0] aximm_client_awid,
+    output logic [AXI4_ADDRW-1:0] aximm_client_awaddr,
+    output logic [AXI4_LENW-1:0] aximm_client_awlen,
+    output logic [AXI4_SIZEW-1:0] aximm_client_awsize,
+    output logic [AXI4_BURSTW-1:0] aximm_client_awburst,
+    output logic [AXI4_USERW-1:0] aximm_client_awuser,
+    // AXI-MM Data Write Channel
+    output logic aximm_client_wvalid,
+    input aximm_client_wready,
+    output logic [AXI4_IDW-1:0] aximm_client_wid,
+    output logic [AXI4_MAX_DATAW-1:0] aximm_client_wdata,
+    output logic aximm_client_wlast,
+    output logic [AXI4_USERW-1:0] aximm_client_wuser,
+    // AXI-MM Write Response Channel
+    input aximm_client_bvalid,
+    output logic aximm_client_bready,
+    input [AXI4_IDW-1:0] aximm_client_bid,
+    input [AXI4_RESPW-1:0] aximm_client_bresp,
+    input [AXI4_USERW-1:0] aximm_client_buser,
+    // AXI-MM Address Read Channel
+    output logic aximm_client_arvalid,
+    input aximm_client_arready,
+    output logic [AXI4_IDW-1:0] aximm_client_arid,
+    output logic [AXI4_ADDRW-1:0] aximm_client_araddr,
+    output logic [AXI4_LENW-1:0] aximm_client_arlen,
+    output logic [AXI4_SIZEW-1:0] aximm_client_arsize,
+    output logic [AXI4_BURSTW-1:0] aximm_client_arburst,
+    output logic [AXI4_USERW-1:0] aximm_client_aruser,
+    // AXI-MM Data Read Channel
+    input aximm_client_rvalid,
+    output logic aximm_client_rready,
+    input [AXI4_IDW-1:0] aximm_client_rid,
+    input [AXI4_MAX_DATAW-1:0] aximm_client_rdata,
+    input [AXI4_RESPW-1:0] aximm_client_rresp,
+    input aximm_client_rlast,
+    input [AXI4_USERW-1:0] aximm_client_ruser
+);
+    localparam RST_STATE=3'b000, AW_STATE=3'b001, W_STATE=3'b010, B_STATE=3'b011, AR_STATE=3'b100, R_STATE=3'b101, END_STATE=3'b110;
+    localparam DEST_ADDR = DST_NODE << (AXI4_ADDRW-4) | DST_MEM_ADDR;
+    localparam SRC_ADDR = SRC_NODE << (AXI4_ADDRW-4);
+
+    logic [2:0] current_state;
+    logic [2:0] next_state;
+
+    always_comb begin
+        case (current_state)
+            RST_STATE: next_state = AW_STATE;
+            AW_STATE: next_state = W_STATE;
+            W_STATE: next_state = B_STATE;
+            B_STATE: next_state = AR_STATE;
+            AR_STATE: next_state = R_STATE;
+            R_STATE: next_state = END_STATE;
+            default: next_state = END_STATE;
+        endcase
+    end
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            current_state <= RST_STATE;
+            start_rdy <= 1'b0;
+            output_result <= 1'b0;
+            output_valid <= 1'b0;
+            aximm_client_awvalid <= 1'b0;
+            aximm_client_awid <= 0;
+            aximm_client_awaddr <= 0;
+            aximm_client_awlen <= 0;
+            aximm_client_awsize <= 0;
+            aximm_client_awburst <= 0;
+            aximm_client_awuser <= 0;
+            aximm_client_wvalid <= 1'b0;
+            aximm_client_wid <= 0;
+            aximm_client_wdata <= 0;
+            aximm_client_wlast <= 1'b0;
+            aximm_client_wuser <= 0;
+            aximm_client_bready <= 1'b0;
+            aximm_client_arvalid <= 1'b0;
+            aximm_client_arid <= 0;
+            aximm_client_araddr <= 0;
+            aximm_client_arlen <= 0;
+            aximm_client_arsize <= 0;
+            aximm_client_arburst <= 0;
+            aximm_client_aruser <= 0;
+            aximm_client_rready <= 1'b0;
+        end else begin
+            start_rdy <= 1'b1;
+			if (current_state == RST_STATE) begin
+                output_result <= 1'b0;
+                output_valid <= 1'b0;
+                aximm_client_awvalid <= 1'b0;
+                aximm_client_awid <= 0;
+                aximm_client_awaddr <= 0;
+                aximm_client_awlen <= 0;
+                aximm_client_awsize <= 0;
+                aximm_client_awburst <= 0;
+                aximm_client_awuser <= 0;
+                aximm_client_wvalid <= 1'b0;
+                aximm_client_wid <= 0;
+                aximm_client_wdata <= 0;
+                aximm_client_wlast <= 1'b0;
+                aximm_client_wuser <= 0;
+                aximm_client_bready <= 1'b0;
+                aximm_client_arvalid <= 1'b0;
+                aximm_client_arid <= 0;
+                aximm_client_araddr <= 0;
+                aximm_client_arlen <= 0;
+                aximm_client_arsize <= 0;
+                aximm_client_arburst <= 0;
+                aximm_client_aruser <= 0;
+                aximm_client_rready <= 1'b0;
+                if (start_sig) begin // wait for driver to start
+                    current_state <= next_state;
+                end
+            end else if (current_state == AW_STATE) begin
+                aximm_client_awaddr <= DEST_ADDR;
+                aximm_client_awid <= 0;
+                aximm_client_awlen <= 0;
+                aximm_client_awburst <= 0;
+                aximm_client_awsize <= 3'b110;
+                aximm_client_awuser <= SRC_ADDR;
+
+                if (aximm_client_awvalid && aximm_client_awready) begin
+                    aximm_client_awvalid <= 1'b0;
+                    current_state <= next_state;
+                    $display("Sent AW Transaction!");
+                end else begin
+                    aximm_client_awvalid <= 1'b1;
+                end
+            end else if (current_state == W_STATE) begin
+                aximm_client_wid <= 0;
+                aximm_client_wdata <= DATA;
+                aximm_client_wlast <= 1'b1;
+                aximm_client_wuser <= SRC_ADDR;
+                
+                if (aximm_client_wvalid && aximm_client_wready) begin
+                    aximm_client_wvalid <= 1'b0;
+                    current_state <= next_state;
+                    $display("Sent W Transaction: %h!", DATA);
+                end else begin
+                    aximm_client_wvalid <= 1'b1;
+                end
+            end else if (current_state == B_STATE) begin
+                aximm_client_bready <= 1'b1;
+
+                if (aximm_client_bvalid && aximm_client_bready) begin
+                    aximm_client_bready <= 1'b0;
+
+                    current_state <= next_state;
+                    $display("Received B Transaction!");
+                end
+            end else if (current_state == AR_STATE) begin
+                aximm_client_araddr <= DEST_ADDR;
+                aximm_client_arid <= 0;
+                aximm_client_arlen <= 0;
+                aximm_client_arburst <= 0;
+                aximm_client_arsize <= 3'b110;
+                aximm_client_aruser <= SRC_ADDR;
+                
+                if (aximm_client_arvalid && aximm_client_arready) begin
+                    aximm_client_arvalid <= 1'b0;
+                    current_state <= next_state;
+                    $display("Sent AR Transaction!");
+                end else begin
+                    aximm_client_arvalid <= 1'b1;
+                end
+            end else if (current_state == R_STATE) begin
+                aximm_client_rready <= 1'b1;
+
+                if (aximm_client_rvalid && aximm_client_rready) begin
+                    aximm_client_rready <= 1'b0;
+
+                    current_state <= next_state;
+                    $display("Received R Transaction: %h!", aximm_client_rdata);
+
+                    output_result <= aximm_client_rdata;
+                    output_valid <= 1'b1;
+                end
+            end
+        end
+    end
+endmodule

--- a/rad-sim/example-designs/rtl_aximm/modules/rtl/memory.sv
+++ b/rad-sim/example-designs/rtl_aximm/modules/rtl/memory.sv
@@ -1,0 +1,54 @@
+module memory # (
+	parameter DATAW = 8,
+	parameter DEPTH = 512,
+	parameter ADDRW = $clog2(DEPTH)
+)(
+	input  clk,
+	input  rst,
+	input  [ADDRW-1:0] waddr,
+	input  wen,
+	input  [DATAW-1:0] wdata,
+	input  [ADDRW-1:0] raddr,
+	output [DATAW-1:0] rdata
+);
+
+reg [DATAW-1:0] mem [0:DEPTH-1];
+
+reg [ADDRW-1:0] r_raddr, r_waddr;
+reg [DATAW-1:0] r_rdata, r_wdata;
+reg r_wen;
+
+integer i;
+
+initial begin
+	for (i = 0; i < DEPTH; i = i + 1) begin
+		mem[i] = 0;
+	end
+end
+
+always @ (posedge clk) begin
+	if (rst) begin
+		r_raddr <= 0;
+		r_waddr <= 0;
+		r_wdata <= 0;
+		r_rdata <= 0;
+	end else begin
+		r_raddr <= raddr;
+		r_wen <= wen;
+		r_waddr <= waddr;
+		r_wdata <= wdata;
+		
+		// Data Forwarding
+		if (r_wen && r_raddr == r_waddr) begin
+			r_rdata <= r_wdata;
+		end else begin
+			r_rdata <= mem[r_raddr];
+		end
+		
+		if (r_wen) mem[r_waddr] <= r_wdata;
+	end
+end
+
+assign rdata = r_rdata;
+
+endmodule

--- a/rad-sim/example-designs/rtl_aximm/modules/rtl/port.map
+++ b/rad-sim/example-designs/rtl_aximm/modules/rtl/port.map
@@ -1,0 +1,81 @@
+module client
+input 1 clk clk
+input 1 rst rst
+input 1 start_sig start_sig
+output 1 start_rdy start_rdy
+output 1 output_valid output_valid
+output 1 output_result output_result
+input 1 output_rdy output_rdy
+aximm master aximm_client_awvalid aximm_client awvalid
+aximm master aximm_client_awready aximm_client awready
+aximm master aximm_client_awid aximm_client awid
+aximm master aximm_client_awaddr aximm_client awaddr
+aximm master aximm_client_awlen aximm_client awlen
+aximm master aximm_client_awsize aximm_client awsize
+aximm master aximm_client_awburst aximm_client awburst
+aximm master aximm_client_awuser aximm_client awuser
+aximm master aximm_client_wvalid aximm_client wvalid
+aximm master aximm_client_wready aximm_client wready
+aximm master aximm_client_wid aximm_client wid
+aximm master aximm_client_wdata aximm_client wdata
+aximm master aximm_client_wlast aximm_client wlast
+aximm master aximm_client_wuser aximm_client wuser
+aximm master aximm_client_bvalid aximm_client bvalid
+aximm master aximm_client_bready aximm_client bready
+aximm master aximm_client_bid aximm_client bid
+aximm master aximm_client_bresp aximm_client bresp
+aximm master aximm_client_buser aximm_client buser
+aximm master aximm_client_arvalid aximm_client arvalid
+aximm master aximm_client_arready aximm_client arready
+aximm master aximm_client_arid aximm_client arid
+aximm master aximm_client_araddr aximm_client araddr
+aximm master aximm_client_arlen aximm_client arlen
+aximm master aximm_client_arsize aximm_client arsize
+aximm master aximm_client_arburst aximm_client arburst
+aximm master aximm_client_aruser aximm_client aruser
+aximm master aximm_client_rvalid aximm_client rvalid
+aximm master aximm_client_rready aximm_client rready
+aximm master aximm_client_rid aximm_client rid
+aximm master aximm_client_rdata aximm_client rdata
+aximm master aximm_client_rresp aximm_client rresp
+aximm master aximm_client_rlast aximm_client rlast
+aximm master aximm_client_ruser aximm_client ruser
+
+module server
+input 1 clk clk
+input 1 rst rst
+aximm slave aximm_server_awvalid aximm_server awvalid
+aximm slave aximm_server_awready aximm_server awready
+aximm slave aximm_server_awid aximm_server awid
+aximm slave aximm_server_awaddr aximm_server awaddr
+aximm slave aximm_server_awlen aximm_server awlen
+aximm slave aximm_server_awsize aximm_server awsize
+aximm slave aximm_server_awburst aximm_server awburst
+aximm slave aximm_server_awuser aximm_server awuser
+aximm slave aximm_server_wvalid aximm_server wvalid
+aximm slave aximm_server_wready aximm_server wready
+aximm slave aximm_server_wid aximm_server wid
+aximm slave aximm_server_wdata aximm_server wdata
+aximm slave aximm_server_wlast aximm_server wlast
+aximm slave aximm_server_wuser aximm_server wuser
+aximm slave aximm_server_bvalid aximm_server bvalid
+aximm slave aximm_server_bready aximm_server bready
+aximm slave aximm_server_bid aximm_server bid
+aximm slave aximm_server_bresp aximm_server bresp
+aximm slave aximm_server_buser aximm_server buser
+aximm slave aximm_server_arvalid aximm_server arvalid
+aximm slave aximm_server_arready aximm_server arready
+aximm slave aximm_server_arid aximm_server arid
+aximm slave aximm_server_araddr aximm_server araddr
+aximm slave aximm_server_arlen aximm_server arlen
+aximm slave aximm_server_arsize aximm_server arsize
+aximm slave aximm_server_arburst aximm_server arburst
+aximm slave aximm_server_aruser aximm_server aruser
+aximm slave aximm_server_rvalid aximm_server rvalid
+aximm slave aximm_server_rready aximm_server rready
+aximm slave aximm_server_rid aximm_server rid
+aximm slave aximm_server_rdata aximm_server rdata
+aximm slave aximm_server_rresp aximm_server rresp
+aximm slave aximm_server_rlast aximm_server rlast
+aximm slave aximm_server_ruser aximm_server ruser
+

--- a/rad-sim/example-designs/rtl_aximm/modules/rtl/server.sv
+++ b/rad-sim/example-designs/rtl_aximm/modules/rtl/server.sv
@@ -1,0 +1,197 @@
+module server # (
+    parameter MEM_SIZE = 64,
+    parameter MEM_ADDRW = $clog2(MEM_SIZE),
+    parameter AXI4_IDW = 8,
+    parameter AXI4_ADDRW = 64,
+    parameter AXI4_LENW = 8,
+    parameter AXI4_SIZEW = 3,
+    parameter AXI4_BURSTW = 2,
+    parameter AXI4_USERW = 64,
+    parameter AXI4_MAX_DATAW = 512,
+    parameter AXI4_RESPW = 2
+) (
+	input clk,
+    input rst,
+    // AXI-MM Address Write Channel
+    input aximm_server_awvalid,
+    output logic aximm_server_awready,
+    input [AXI4_IDW-1:0] aximm_server_awid,
+    input [AXI4_ADDRW-1:0] aximm_server_awaddr,
+    input [AXI4_LENW-1:0] aximm_server_awlen,
+    input [AXI4_SIZEW-1:0] aximm_server_awsize,
+    input [AXI4_BURSTW-1:0] aximm_server_awburst,
+    input [AXI4_USERW-1:0] aximm_server_awuser,
+    // AXI-MM Data Write Channel
+    input aximm_server_wvalid,
+    output logic aximm_server_wready,
+    input [AXI4_IDW-1:0] aximm_server_wid,
+    input [AXI4_MAX_DATAW-1:0] aximm_server_wdata,
+    input aximm_server_wlast,
+    input [AXI4_USERW-1:0] aximm_server_wuser,
+    // AXI-MM Write Response Channel
+    output logic aximm_server_bvalid,
+    input aximm_server_bready,
+    output logic [AXI4_IDW-1:0] aximm_server_bid,
+    output logic [AXI4_RESPW-1:0] aximm_server_bresp,
+    output logic [AXI4_USERW-1:0] aximm_server_buser,
+    // AXI-MM Address Read Channel
+    input aximm_server_arvalid,
+    output logic aximm_server_arready,
+    input [AXI4_IDW-1:0] aximm_server_arid,
+    input [AXI4_ADDRW-1:0] aximm_server_araddr,
+    input [AXI4_LENW-1:0] aximm_server_arlen,
+    input [AXI4_SIZEW-1:0] aximm_server_arsize,
+    input [AXI4_BURSTW-1:0] aximm_server_arburst,
+    input [AXI4_USERW-1:0] aximm_server_aruser,
+    // AXI-MM Data Read Channel
+    output logic aximm_server_rvalid,
+    input aximm_server_rready,
+    output logic [AXI4_IDW-1:0] aximm_server_rid,
+    output logic [AXI4_MAX_DATAW-1:0] aximm_server_rdata,
+    output logic [AXI4_RESPW-1:0] aximm_server_rresp,
+    output logic aximm_server_rlast,
+    output logic [AXI4_USERW-1:0] aximm_server_ruser
+);
+    localparam RST_STATE = 4'b0000,
+               AW_STATE = 4'b0001,
+               W_STATE = 4'b0010,
+               B_STATE = 4'b0011,
+               AR_STATE = 4'b0100,
+               MEM_SETTLE1_STATE = 4'b0101,
+               MEM_SETTLE2_STATE = 4'b0110,
+               R_STATE = 4'b0111,
+               END_STATE = 4'b1000;
+
+    logic [3:0] current_state;
+    logic [3:0] next_state;
+
+    logic [MEM_ADDRW-1:0] memory_waddr;
+    logic memory_wen;
+    logic [AXI4_MAX_DATAW-1:0] memory_wdata;
+    logic [MEM_ADDRW-1:0] memory_raddr;
+    logic [AXI4_MAX_DATAW-1:0] memory_rdata;
+    logic [MEM_ADDRW-1:0] r_memory_raddr;
+    logic [MEM_ADDRW-1:0] rr_memory_raddr;
+
+    logic [AXI4_USERW-1:0] dest_addr;
+
+    memory #(
+        .DATAW(AXI4_MAX_DATAW),
+        .DEPTH(MEM_SIZE)
+    ) aximm_memory (
+        .clk(clk),
+	    .rst(rst),
+	    .waddr(memory_waddr),
+	    .wen(memory_wen),
+	    .wdata(memory_wdata),
+	    .raddr(memory_raddr),
+	    .rdata(memory_rdata)
+    );
+
+    always_comb begin
+        case (current_state)
+            RST_STATE: next_state = AW_STATE;
+            AW_STATE: next_state = W_STATE;
+            W_STATE: next_state = B_STATE;
+            B_STATE: next_state = AR_STATE;
+            AR_STATE: next_state = MEM_SETTLE1_STATE;
+            MEM_SETTLE1_STATE: next_state = MEM_SETTLE2_STATE;
+            MEM_SETTLE2_STATE: next_state = R_STATE;
+            R_STATE: next_state = END_STATE;
+            default: next_state = END_STATE;
+        endcase
+    end
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            aximm_server_awready <= 1'b0;
+            aximm_server_wready <= 1'b0;
+            aximm_server_bvalid <= 1'b0;
+            aximm_server_bid <= 0;
+            aximm_server_bresp <= 0;
+            aximm_server_buser <= 0;
+            aximm_server_arready <= 1'b0;
+            aximm_server_rvalid <= 1'b0;
+            aximm_server_rid <= 0;
+            aximm_server_rdata <= 0;
+            aximm_server_rresp <= 0;
+            aximm_server_rlast <= 1'b0;
+            aximm_server_ruser <= 0;
+
+            dest_addr <= 0;
+
+            current_state <= RST_STATE;
+        end else begin
+            if (current_state == RST_STATE) begin
+                aximm_server_awready <= 1'b0;
+                aximm_server_wready <= 1'b0;
+                aximm_server_bvalid <= 1'b0;
+                aximm_server_bid <= 0;
+                aximm_server_bresp <= 0;
+                aximm_server_buser <= 0;
+                aximm_server_arready <= 1'b0;
+                aximm_server_rvalid <= 1'b0;
+                aximm_server_rid <= 0;
+                aximm_server_rdata <= 0;
+                aximm_server_rresp <= 0;
+                aximm_server_rlast <= 1'b0;
+                aximm_server_ruser <= 0;
+
+                dest_addr <= 0;
+
+                current_state <= next_state;
+            end else if (current_state == AW_STATE) begin
+                aximm_server_awready <= 1'b1;
+                if (aximm_server_awready && aximm_server_awvalid) begin
+                    aximm_server_awready <= 1'b0;
+                    memory_waddr <= aximm_server_awaddr;
+                    current_state <= next_state;
+                end
+            end else if (current_state == W_STATE) begin
+                aximm_server_wready <= 1'b1;
+                if (aximm_server_wready && aximm_server_wvalid) begin
+                    aximm_server_wready <= 1'b0;
+                    memory_wdata <= aximm_server_wdata;
+                    memory_wen <= 1'b1;
+                    dest_addr <= aximm_server_wuser;
+                    current_state <= next_state;
+                end
+            end else if (current_state == B_STATE) begin
+                memory_wen <= 1'b0;
+                aximm_server_bid <= 0;
+                aximm_server_buser <= dest_addr;
+                aximm_server_bresp <= 0;
+
+                if (aximm_server_bvalid && aximm_server_bready) begin
+                    aximm_server_bvalid <= 1'b0;
+                    current_state <= next_state;
+                end else begin
+                    aximm_server_bvalid <= 1'b1;
+                end
+            end else if (current_state == AR_STATE) begin
+                aximm_server_arready <= 1'b1;
+                if (aximm_server_arready && aximm_server_arvalid) begin
+                    aximm_server_arready <= 1'b0;
+                    memory_raddr <= aximm_server_araddr[MEM_ADDRW-1:0];
+                    dest_addr <= aximm_server_aruser;
+                    current_state <= next_state;
+                end
+            end else if (current_state == MEM_SETTLE1_STATE || current_state == MEM_SETTLE2_STATE) begin
+                current_state <= next_state;
+            end else if (current_state == R_STATE) begin
+                aximm_server_rid <= 0;
+                aximm_server_rdata <= memory_rdata;
+                aximm_server_rlast <= 1'b1;
+                aximm_server_ruser <= dest_addr;
+                aximm_server_rresp <= 0;
+
+                if (aximm_server_rvalid && aximm_server_rready) begin
+                    aximm_server_rvalid <= 1'b0;
+                    current_state <= next_state;
+                end else begin
+                    aximm_server_rvalid <= 1'b1;
+                end
+            end
+        end
+    end
+endmodule

--- a/rad-sim/example-designs/rtl_aximm/modules/server.cpp
+++ b/rad-sim/example-designs/rtl_aximm/modules/server.cpp
@@ -1,0 +1,64 @@
+#include <server.hpp>
+
+server::server(const sc_module_name &name) : RADSimModule(name) {
+	char vserver_name[25];
+	std::string vserver_name_str = std::string(name);
+	std::strcpy(vserver_name, vserver_name_str.c_str());
+
+	vserver = new Vserver{vserver_name};
+	vserver->clk(clk);
+	vserver->rst(rst);
+	vserver->aximm_server_awvalid(aximm_server.awvalid);
+	vserver->aximm_server_awready(aximm_server.awready);
+	vserver->aximm_server_awid(aximm_server.awid);
+	vserver->aximm_server_awaddr(aximm_server.awaddr);
+	vserver->aximm_server_awlen(aximm_server.awlen);
+	vserver->aximm_server_awsize(aximm_server.awsize);
+	vserver->aximm_server_awburst(aximm_server.awburst);
+	vserver->aximm_server_awuser(aximm_server.awuser);
+	vserver->aximm_server_wvalid(aximm_server.wvalid);
+	vserver->aximm_server_wready(aximm_server.wready);
+	vserver->aximm_server_wid(aximm_server.wid);
+	vserver->aximm_server_wdata(aximm_server.wdata);
+	vserver->aximm_server_wlast(aximm_server.wlast);
+	vserver->aximm_server_wuser(aximm_server.wuser);
+	vserver->aximm_server_bvalid(aximm_server.bvalid);
+	vserver->aximm_server_bready(aximm_server.bready);
+	vserver->aximm_server_bid(aximm_server.bid);
+	vserver->aximm_server_bresp(aximm_server.bresp);
+	vserver->aximm_server_buser(aximm_server.buser);
+	vserver->aximm_server_arvalid(aximm_server.arvalid);
+	vserver->aximm_server_arready(aximm_server.arready);
+	vserver->aximm_server_arid(aximm_server.arid);
+	vserver->aximm_server_araddr(aximm_server.araddr);
+	vserver->aximm_server_arlen(aximm_server.arlen);
+	vserver->aximm_server_arsize(aximm_server.arsize);
+	vserver->aximm_server_arburst(aximm_server.arburst);
+	vserver->aximm_server_aruser(aximm_server.aruser);
+	vserver->aximm_server_rvalid(aximm_server.rvalid);
+	vserver->aximm_server_rready(aximm_server.rready);
+	vserver->aximm_server_rid(aximm_server.rid);
+	vserver->aximm_server_rdata(aximm_server.rdata);
+	vserver->aximm_server_rresp(aximm_server.rresp);
+	vserver->aximm_server_rlast(aximm_server.rlast);
+	vserver->aximm_server_ruser(aximm_server.ruser);
+
+	this->RegisterModuleInfo();
+}
+
+server::~server() {
+	vserver->final();
+	delete vserver;
+}
+
+void server::RegisterModuleInfo() {
+	std::string port_name;
+	_num_noc_axis_slave_ports = 0;
+	_num_noc_axis_master_ports = 0;
+	_num_noc_aximm_slave_ports = 0;
+	_num_noc_aximm_master_ports = 0;
+
+	port_name = module_name + ".aximm_server";
+	RegisterAximmSlavePort(port_name, &aximm_server, 512);
+
+}

--- a/rad-sim/example-designs/rtl_aximm/modules/server.hpp
+++ b/rad-sim/example-designs/rtl_aximm/modules/server.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <aximm_interface.hpp>
+#include <design_context.hpp>
+#include <radsim_defines.hpp>
+#include <radsim_module.hpp>
+#include <string>
+#include <systemc.h>
+#include <vector>
+
+#include <Vserver.h>
+class server : public RADSimModule {
+private:
+	Vserver* vserver;
+
+public:
+	sc_in<bool> rst;
+
+	aximm_slave_port aximm_server;
+
+	server(const sc_module_name &name);
+	~server();
+
+	SC_HAS_PROCESS(server);
+	void RegisterModuleInfo();
+};

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm.clks
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm.clks
@@ -1,0 +1,2 @@
+client_inst 0 0
+server_inst 0 0

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm.place
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm.place
@@ -1,0 +1,2 @@
+client_inst 0 0 aximm
+server_inst 0 2 aximm

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm_driver.cpp
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm_driver.cpp
@@ -1,0 +1,51 @@
+#include <rtl_aximm_driver.hpp>
+
+rtl_aximm_driver::rtl_aximm_driver(const sc_module_name &name)
+    : sc_module(name) {
+
+  // Parse design configuration (number of layers & number of MVM per layer)
+  std::string design_root_dir =
+      radsim_config.GetStringKnob("radsim_user_design_root_dir");
+
+  SC_CTHREAD(source, clk.pos());
+  SC_CTHREAD(sink, clk.pos());
+}
+
+rtl_aximm_driver::~rtl_aximm_driver() {}
+
+void rtl_aximm_driver::source() {
+  // Reset
+  rst.write(true);
+  start_sig.write(false);
+  wait();
+  rst.write(false);
+  wait();
+  while (true) {
+    if (start_rdy.read()) {
+      start_sig.write(1);
+    }
+
+    wait();
+  }
+  
+  wait();
+}
+
+void rtl_aximm_driver::sink() {
+  std::string dst_port_name = "server_inst.aximm_server";
+  uint64_t dst_addr = radsim_design.GetPortBaseAddress(dst_port_name);
+  std::cout << dst_addr << std::endl;
+  while(true) {
+    if (output_valid) {
+      if (output_result) {
+        std::cout << "SUCCESS - R Transaction matches W Transaction!" << std::endl;
+      } else {
+        std::cout << "FAILURE - R Transaction does not match W Transaction!" << std::endl;
+        radsim_design.ReportDesignFailure();
+      }
+      break;
+    }
+    wait();
+  }
+  sc_stop();
+}

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm_driver.hpp
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm_driver.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <chrono>
+#include <radsim_config.hpp>
+#include <design_context.hpp>
+#include <stdlib.h>
+#include <systemc.h>
+#include <time.h>
+#include <vector>
+
+class rtl_aximm_driver : public sc_module {
+public:
+  sc_in<bool> clk;
+  sc_out<bool> rst;
+  // Client Interface
+  sc_out<bool> start_sig;
+	sc_in<bool> start_rdy;
+	sc_in<bool> output_valid;
+	sc_in<bool> output_result;
+	sc_out<bool> output_rdy;
+
+  rtl_aximm_driver(const sc_module_name &name);
+  ~rtl_aximm_driver();
+
+  void source();
+  void sink();
+
+  SC_HAS_PROCESS(rtl_aximm_driver);
+};

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm_system.cpp
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm_system.cpp
@@ -1,0 +1,29 @@
+#include <rtl_aximm_system.hpp>
+
+rtl_aximm_system::rtl_aximm_system(const sc_module_name &name, sc_clock *driver_clk_sig) : sc_module(name) {
+
+  // Instantiate driver
+  driver_inst = new rtl_aximm_driver("driver");
+  driver_inst->clk(*driver_clk_sig);
+  driver_inst->rst(rst_sig);
+  driver_inst->start_sig(start_sig);
+	driver_inst->start_rdy(start_rdy);
+	driver_inst->output_valid(output_valid);
+	driver_inst->output_result(output_result);
+	driver_inst->output_rdy(output_rdy);
+
+  // Instantiate design top-level
+  dut_inst = new rtl_aximm_top("dut");
+  dut_inst->rst(rst_sig);
+  dut_inst->start_sig(start_sig);
+	dut_inst->start_rdy(start_rdy);
+	dut_inst->output_valid(output_valid);
+	dut_inst->output_result(output_result);
+	dut_inst->output_rdy(output_rdy);
+}
+
+rtl_aximm_system::~rtl_aximm_system() {
+  delete driver_inst;
+  delete dut_inst;
+  delete sysclk;
+}

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm_system.hpp
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm_system.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <rtl_aximm_driver.hpp>
+#include <rtl_aximm_top.hpp>
+#include <chrono>
+#include <vector>
+
+class rtl_aximm_system : public sc_module {
+private:
+  // Client Interface
+  sc_signal<bool> start_sig;
+	sc_signal<bool> start_rdy;
+	sc_signal<bool> output_valid;
+	sc_signal<bool> output_result;
+	sc_signal<bool> output_rdy;
+
+public:
+  sc_signal<bool> rst_sig;
+  sc_clock *sysclk;
+  rtl_aximm_driver *driver_inst;
+  rtl_aximm_top *dut_inst;
+
+  rtl_aximm_system(const sc_module_name &name,
+                           sc_clock *driver_clk_sig);
+  ~rtl_aximm_system();
+};

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm_top.cpp
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm_top.cpp
@@ -1,0 +1,34 @@
+#include <rtl_aximm_top.hpp>
+
+rtl_aximm_top::rtl_aximm_top(const sc_module_name &name)
+    : sc_module(name) {
+
+  std::string module_name_str;
+  char module_name[25];
+
+  module_name_str = "client_inst";
+  std::strcpy(module_name, module_name_str.c_str());
+
+  client_inst = new client(module_name);
+  client_inst->rst(rst);
+  client_inst->start_sig(start_sig);
+	client_inst->start_rdy(start_rdy);
+	client_inst->output_valid(output_valid);
+	client_inst->output_result(output_result);
+	client_inst->output_rdy(output_rdy);
+
+  module_name_str = "server_inst";
+  std::strcpy(module_name, module_name_str.c_str());
+
+  server_inst = new server(module_name);
+  server_inst->rst(rst);
+
+  radsim_design.BuildDesignContext("rtl_aximm.place",
+                                   "rtl_aximm.clks");
+  radsim_design.CreateSystemNoCs(rst);
+  radsim_design.ConnectModulesToNoC();
+}
+
+rtl_aximm_top::~rtl_aximm_top() {
+  delete client_inst;
+}

--- a/rad-sim/example-designs/rtl_aximm/rtl_aximm_top.hpp
+++ b/rad-sim/example-designs/rtl_aximm/rtl_aximm_top.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <radsim_config.hpp>
+#include <client.hpp>
+#include <server.hpp>
+#include <systemc.h>
+#include <vector>
+
+class rtl_aximm_top : public sc_module {
+private:
+  client *client_inst;
+  server *server_inst;
+
+public:
+  sc_in<bool> rst;
+  // Client Interface
+  sc_in<bool> start_sig;
+	sc_out<bool> start_rdy;
+	sc_out<bool> output_valid;
+	sc_out<bool> output_result;
+	sc_in<bool> output_rdy;
+
+  rtl_aximm_top(const sc_module_name &name);
+  ~rtl_aximm_top();
+};

--- a/rad-sim/scripts/generate_port_mappings.py
+++ b/rad-sim/scripts/generate_port_mappings.py
@@ -1,7 +1,6 @@
 # Port Mapping Parser Script
 # Parses inputs and outputs from top-level Verilog designs and maps it to the port.map format used by Wrapper Generation
-# Support for AXI-S interfaces parsing
-# TODO: add support for AXI-MM
+# Support for AXI-S, AXI-MM interfaces parsing
 # Arguments:
 #   [1] => Path to the design folder
 #   [2...] => Verilog files for top-level designs
@@ -12,8 +11,14 @@ from pathlib import Path
 
 verilog_range_regex = "\[(\d*):(\d*)\]"
 verilog_axis_regex = "axis_(.*)_(.*)"
+verilog_aximm_regex = "aximm_(.*)_(.*)"
 
 axis_slave_input_ports = ["tvalid", "tdata", "tstrb", "tkeep", "tlast", "tid", "tdest", "tuser"]
+aximm_slave_input_ports = ["awvalid", "awid", "awaddr", "awlen", "awsize", "awburst", "awuser",
+                           "wvalid", "wid", "wdata", "wlast", "wuser",
+                           "bready",
+                           "arvalid", "arid", "araddr", "arlen", "arsize", "arburst", "aruser",
+                           "rready"]
 
 # Determines the width of the port. Outputs the width if successful, "?" if failure
 def determine_port_width(port):
@@ -40,9 +45,20 @@ def match_axis_regex(port):
     signal = re.match(verilog_axis_regex, port.name)
     return signal.groups()
 
+# RegEx pattern matching for AXI-MM ports. Returns capture groups with information on the AXI-MM interface name, and the AXI-MM port.
+def match_aximm_regex(port):
+    signal = re.match(verilog_aximm_regex, port.name)
+    return signal.groups()
+
 # Determines if a port is an AXI-S port
 def is_axis_port(port):
     if re.match(verilog_axis_regex, port.name):
+        return True
+    return False
+
+# Determines if a port is an AXI-MM port
+def is_aximm_port(port):
+    if re.match(verilog_aximm_regex, port.name):
         return True
     return False
 
@@ -50,6 +66,13 @@ def is_axis_port(port):
 def is_axis_role_found(axis_roles, port):
     (axis_interface, axis_port) = match_axis_regex(port)
     if axis_interface in axis_roles:
+        return True
+    return False
+
+# Determines if the role for an AXI-MM port has already been saved
+def is_aximm_role_found(aximm_roles, port):
+    (aximm_interface, aximm_port) = match_aximm_regex(port)
+    if aximm_interface in aximm_roles:
         return True
     return False
 
@@ -63,13 +86,23 @@ def determine_axis_roles(module):
                 axis_roles[axis_interface] = "slave" if p.mode == "input" else "master"
     return axis_roles
 
+# Determines the AXI-MM roles for a given module.
+def determine_aximm_roles(module):
+    aximm_roles = {}
+    for p in module.ports:
+        if is_aximm_port(p) and not is_aximm_role_found(aximm_roles, p):
+            (aximm_interface, aximm_port) = match_aximm_regex(p)
+            if aximm_port in aximm_slave_input_ports:
+                aximm_roles[aximm_interface] = "slave" if p.mode == "input" else "master"
+    return aximm_roles
+
 # Parses modules from a Verilog File
 def get_modules_from_verilog_file(verilog_file_path):
     vlog_ex = vlog.VerilogExtractor()
     return vlog_ex.extract_objects(verilog_file_path)
 
 # Main function for a single module
-def generate_port_mappings_for_module(port_mapping_file, module, axis_roles):
+def generate_port_mappings_for_module(port_mapping_file, module, axis_roles, aximm_roles):
     warnings = False
     port_mapping_file.write("module {0}\n".format(module.name))
     for p in module.ports:
@@ -77,6 +110,10 @@ def generate_port_mappings_for_module(port_mapping_file, module, axis_roles):
             (axis_interface, axis_port) = match_axis_regex(p)
             axis_role = axis_roles[axis_interface]
             port_mapping_file.write("axis {0} {1} axis_{2} {3}\n".format(axis_role, p.name, axis_interface, axis_port))
+        elif is_aximm_port(p) and is_aximm_role_found(aximm_roles, p):
+            (aximm_interface, aximm_port) = match_aximm_regex(p)
+            aximm_role = aximm_roles[aximm_interface]
+            port_mapping_file.write("aximm {0} {1} aximm_{2} {3}\n".format(aximm_role, p.name, aximm_interface, aximm_port))
         else:
             port_size = determine_port_width(p)
             if port_size == "?":
@@ -120,7 +157,8 @@ def generate(design_folder, rtl_files, cmd_overwrite):
             for m in modules:
                 # Finds all the AXI-S roles (master/slave) for each AXI-S interface
                 axis_roles = determine_axis_roles(m)
-                warnings = True if generate_port_mappings_for_module(port_mapping_file, m, axis_roles) else warnings
+                aximm_roles = determine_aximm_roles(m)
+                warnings = True if generate_port_mappings_for_module(port_mapping_file, m, axis_roles, aximm_roles) else warnings
         if warnings:
             print("WARNING: Successfully generated port mapping file with manual input required.")
             print("Please manually replace '?' with the correct values before running the wrapper generation script.")

--- a/rad-sim/scripts/generate_wrapper.py
+++ b/rad-sim/scripts/generate_wrapper.py
@@ -1,14 +1,13 @@
 # Generate Wrapper Code for RTL Support
 # Creates RAD-Sim modules that instantiates SystemC modules under the hood.
-# Current version only supports AXI-S
-# TODO: add support for AXI-MM
+# Supports AXI-S, AXI-MM
 # Arguments:
 #   [1] => Path to the design folder
 #   [2...] => Modules to generate wrapper code for
 import argparse
 from pathlib import Path
 
-DEFAULT_PORT_WIDTH = 1024 # AXI-S data width
+DEFAULT_PORT_WIDTH = 1024 # AXI-S, AXI-MM data width
 
 # Verilog-style -> SystemC port type translations
 port_type_translation = {
@@ -18,7 +17,7 @@ port_type_translation = {
 }
 
 # Generates the C++ wrapper file
-def generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_roles):
+def generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_roles, aximm_roles):
     verilated_design = "V" + design_name
     design_inst = "v" + design_name
 
@@ -28,7 +27,7 @@ def generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_r
       wrapper_cpp_file.write(design_name + "::" + design_name + "(const sc_module_name &name) : RADSimModule(name) {\n")
 
       wrapper_cpp_file.write("\t" + "char " + design_inst + "_name[25];\n")
-      wrapper_cpp_file.write("\tstd::string " + design_inst + "_name_str = std::string(name) + \"_vmvm\";\n")
+      wrapper_cpp_file.write("\tstd::string " + design_inst + "_name_str = std::string(name);\n")
       wrapper_cpp_file.write("\tstd::strcpy(" + design_inst + "_name, " + design_inst + "_name_str.c_str());\n\n")
       wrapper_cpp_file.write("\t" + design_inst + " = new " + verilated_design + "{" + design_inst + "_name};\n")
 
@@ -41,7 +40,7 @@ def generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_r
         for port in mappings[design_name]:
           wrapper_cpp_file.write("\t" + design_inst + "->" + port[2] + "(" + port[3] + ");\n")
 
-      if axis_roles != None:
+      if axis_roles != None or aximm_roles != None:
         wrapper_cpp_file.write("\n\tthis->RegisterModuleInfo();\n")
       wrapper_cpp_file.write("}\n\n")
 
@@ -50,7 +49,7 @@ def generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_r
       wrapper_cpp_file.write("\tdelete " + design_inst + ";\n")
       wrapper_cpp_file.write("}\n\n")
 
-      if axis_roles != None:
+      if axis_roles != None or aximm_roles != None:
         wrapper_cpp_file.write("void " + design_name + "::RegisterModuleInfo() {\n")
         wrapper_cpp_file.write("\tstd::string port_name;\n")
         wrapper_cpp_file.write("\t_num_noc_axis_slave_ports = 0;\n")
@@ -58,23 +57,37 @@ def generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_r
         wrapper_cpp_file.write("\t_num_noc_aximm_slave_ports = 0;\n")
         wrapper_cpp_file.write("\t_num_noc_aximm_master_ports = 0;\n\n")
 
-        for axis_interface, axis_role in axis_roles.items():
-          wrapper_cpp_file.write("\tport_name = module_name + \"." + axis_interface + "\";\n")
-          if axis_role == "master":
-              wrapper_cpp_file.write("\tRegisterAxisMasterPort(port_name, &" + axis_interface + ", " + dataw + ", 0);\n\n")
-          else:
-              wrapper_cpp_file.write("\tRegisterAxisSlavePort(port_name, &" + axis_interface + ", " + dataw + ", 0);\n\n")
+        if axis_roles != None:
+          for axis_interface, axis_role in axis_roles.items():
+            wrapper_cpp_file.write("\tport_name = module_name + \"." + axis_interface + "\";\n")
+            if axis_role == "master":
+                wrapper_cpp_file.write("\tRegisterAxisMasterPort(port_name, &" + axis_interface + ", " + dataw + ", 0);\n\n")
+            else:
+                wrapper_cpp_file.write("\tRegisterAxisSlavePort(port_name, &" + axis_interface + ", " + dataw + ", 0);\n\n")
+
+        if aximm_roles != None:
+          for aximm_interface, aximm_role in aximm_roles.items():
+            wrapper_cpp_file.write("\tport_name = module_name + \"." + aximm_interface + "\";\n")
+            if aximm_role == "master":
+                wrapper_cpp_file.write("\tRegisterAximmMasterPort(port_name, &" + aximm_interface + ", " + dataw + ");\n\n")
+            else:
+                wrapper_cpp_file.write("\tRegisterAximmSlavePort(port_name, &" + aximm_interface + ", " + dataw + ");\n\n")
         
         wrapper_cpp_file.write("}\n")
 
 # Generates the accompanying C++ header wrapper file
-def generate_header_wrapper(design_name, modules_folder, mappings, axis_roles):
+def generate_header_wrapper(design_name, modules_folder, mappings, axis_roles, aximm_roles):
     verilated_design = "V" + design_name
     design_inst = "v" + design_name
 
     with open(modules_folder / (design_name + ".hpp"), "w") as wrapper_hpp_file:
       wrapper_hpp_file.write("#pragma once\n\n")
-      wrapper_hpp_file.write("#include <axis_interface.hpp>\n")
+
+      if axis_roles != None:
+        wrapper_hpp_file.write("#include <axis_interface.hpp>\n")
+      if aximm_roles != None:
+        wrapper_hpp_file.write("#include <aximm_interface.hpp>\n")
+
       wrapper_hpp_file.write("#include <design_context.hpp>\n")
       wrapper_hpp_file.write("#include <radsim_defines.hpp>\n")
       wrapper_hpp_file.write("#include <radsim_module.hpp>\n")
@@ -95,12 +108,12 @@ def generate_header_wrapper(design_name, modules_folder, mappings, axis_roles):
         print("WARNING: Empty mappings for the module", design_name)
       else:
         for port in mappings[design_name]:
-          if port[0] == "axis": continue # NoC connectors are handled separately
+          if port[0] == "axis" or port[0] == "aximm": continue # NoC connectors are handled separately
           if port[3] == "clk": continue # Clock connection provided by RADSimModule
           port_size_type = "bool" if port[1] == "1" else "sc_bv<" + port[1] + ">"
           wrapper_hpp_file.write("\t" + port[0] + "<" + port_size_type + "> " + port[3] + ";\n")
 
-      # NoC connection
+      # NoC AXI-S connections
       if axis_roles != None:
         wrapper_hpp_file.write("\n")
         for axis_interface, axis_role in axis_roles.items():
@@ -108,12 +121,21 @@ def generate_header_wrapper(design_name, modules_folder, mappings, axis_roles):
               wrapper_hpp_file.write("\taxis_master_port " + axis_interface + ";\n")
           else:
               wrapper_hpp_file.write("\taxis_slave_port " + axis_interface + ";\n")
+      
+      # NoC AXI-MM connections
+      if aximm_roles != None:
+        wrapper_hpp_file.write("\n")
+        for aximm_interface, aximm_role in aximm_roles.items():
+          if aximm_role == "master":
+              wrapper_hpp_file.write("\taximm_master_port " + aximm_interface + ";\n")
+          else:
+              wrapper_hpp_file.write("\taximm_slave_port " + aximm_interface + ";\n")
 
       wrapper_hpp_file.write("\n\t" + design_name + "(const sc_module_name &name);\n")
       wrapper_hpp_file.write("\t~" + design_name + "();\n\n")
 
       wrapper_hpp_file.write("\tSC_HAS_PROCESS(" + design_name + ");\n")
-      if axis_roles != None:
+      if axis_roles != None or aximm_roles != None:
         wrapper_hpp_file.write("\tvoid RegisterModuleInfo();\n")
       wrapper_hpp_file.write("};\n")
 
@@ -122,6 +144,7 @@ def read_port_mappings(port_mapping_file):
   current_module = ""
   mappings = {}
   axis_roles = {}
+  aximm_roles = {}
   with open(port_mapping_file) as pmf:
     for line in pmf:
       components = line.split()
@@ -152,6 +175,23 @@ def read_port_mappings(port_mapping_file):
           # verify there is no inconsistencies
           if axis_roles[current_module][axis_interface] != axis_role:
             raise ValueError("Inconsistent AXI-S role for interface " + axis_interface + ". Each interface can either be master or slave.")
+      elif components[0] == "aximm": # The port mapping line specifies an AXI-MM port
+        # Validity Checks
+        if not current_module: raise ValueError("A module must be specified before mappings for the module.")
+        if len(components) != 5: raise ValueError("Each line specifying an AXI-MM port must contain 5 parameters separated by a whitespace.")
+
+        # Add the parsed data to data structures to be used during wrapper generation
+        (keyword, aximm_role, rtl_port, aximm_interface, aximm_port) = components
+        radsim_port = aximm_interface + "." + aximm_port
+        mappings[current_module].append((keyword, aximm_role, rtl_port, radsim_port))
+        if current_module not in aximm_roles:
+          aximm_roles[current_module] = {}
+        if aximm_interface not in aximm_roles[current_module]:
+          aximm_roles[current_module][aximm_interface] = aximm_role
+        else:
+          # verify there is no inconsistencies
+          if aximm_roles[current_module][aximm_interface] != aximm_role:
+            raise ValueError("Inconsistent AXI-MM role for interface " + aximm_interface + ". Each interface can either be master or slave.")
       else: # The port mapping line specifies any other port
         port_mode = components[0]
         port_width = components[1]
@@ -159,13 +199,13 @@ def read_port_mappings(port_mapping_file):
         # Validity Checks
         if not current_module: raise ValueError("A module must be specified before mappings for the module.")
         if len(components) != 4: raise ValueError("Each line specifying a port can only contain 4 parameters separated by a whitespace.")
-        if port_mode != "input" and port_mode != "output" and port_mode != "inout": raise ValueError("The first argument of each port must be either axis/input/output/inout.")
+        if port_mode != "input" and port_mode != "output" and port_mode != "inout": raise ValueError("The first argument of each port must be either axis/aximm/input/output/inout.")
         if port_width == "?": raise ValueError("Automated port mapping failed for " + components[2] + ". Manually add the port size.")
         if not port_width.isnumeric(): raise ValueError("Port Width must be a number.")
 
         port_mode = port_type_translation[port_mode] # translate input/output/inout to systemC types
         mappings[current_module].append((port_mode, port_width, components[2], components[3]))
-  return (mappings, axis_roles)
+  return (mappings, axis_roles, aximm_roles)
 
 # Main function to generate wrapper files
 def generate(design_folder, design_modules):
@@ -181,18 +221,19 @@ def generate(design_folder, design_modules):
       raise ValueError("The port mapping file does not exist.")
 
   print("Reading Port Mappings...")
-  mappings, axis_roles = read_port_mappings(port_map_file_path)
+  mappings, axis_roles, aximm_roles = read_port_mappings(port_map_file_path)
   print("Read Port Mappings Sucessfully!")
   for i in range(len(design_modules)):
     design_name = design_modules[i]
-    if (axis_roles.get(design_name) != None):
-      dataw = input("Enter the AXI-S data width for module " + design_name + " (default: " + str(DEFAULT_PORT_WIDTH) + "): ")
+    dataw = 0
+    if (axis_roles.get(design_name) != None or aximm_roles.get(design_name) != None):
+      dataw = input("Enter the AXI data width for module " + design_name + " (default: " + str(DEFAULT_PORT_WIDTH) + "): ")
       dataw = dataw if dataw else str(DEFAULT_PORT_WIDTH)
     else:
-      print("WARNING: Module {0} is not connected to the NOC via AXI-S.".format(design_name))
-    generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_roles.get(design_name))
+      print("WARNING: Module {0} is not connected to the NOC via AXI.".format(design_name))
+    generate_source_wrapper(design_name, modules_folder, dataw, mappings, axis_roles.get(design_name), aximm_roles.get(design_name))
     print("Generated Source Wrapper for module", design_name)
-    generate_header_wrapper(design_name, modules_folder, mappings, axis_roles.get(design_name))
+    generate_header_wrapper(design_name, modules_folder, mappings, axis_roles.get(design_name), aximm_roles.get(design_name))
     print("Generated Header Wrapper for module", design_name)
 
 if __name__ == "__main__":

--- a/rad-sim/test/wrapper-scripts/mock_port.map
+++ b/rad-sim/test/wrapper-scripts/mock_port.map
@@ -3,4 +3,6 @@ input 1 i1 i1
 inout 64 io64 io64
 axis master axis_mock_master_tdata axis_mock_master tdata
 axis slave axis_mock_slave_tdata axis_mock_slave tdata
+aximm master aximm_mock_master_wdata aximm_mock_master wdata
+aximm slave aximm_mock_slave_wdata aximm_mock_slave wdata
 output 32 o32 o32

--- a/rad-sim/test/wrapper-scripts/test_generate_port_mappings.py
+++ b/rad-sim/test/wrapper-scripts/test_generate_port_mappings.py
@@ -9,29 +9,37 @@ mock_master_module = VerilogModule("mock_master_module", [
         VerilogParameter("output_w3", "output", "wire [5:3]"), # Port 2: Output with width 3
         VerilogParameter("inout_w2_reg", "inout", "reg [1:0]"), # Port 3: Inout reg with width 2
         VerilogParameter("output_w1_logic", "output", "logic"), # Port 4: Output logic with width 1 (bool)
-        VerilogParameter("axis_mock_master_module_tdata", "output", "logic [`DEF1:`DEF2]"), # Port 5: Output AXI-S logic with unknown width
-        VerilogParameter("axis_mock_master_module_unknown_tunknown", "output") # Port 6: (unknown) Output AXI-S logic with width 1
+        VerilogParameter("axis_mock_master_module_tdata", "output", "logic [`DEF1:`DEF2]") # Port 5: Master AXI-S logic with unknown width
     ])
 
 mock_mixed_module = VerilogModule("mock_mixed_module", [
-        VerilogParameter("axis_mock_master_module_tstrb", "output"), # Port 0: Output AXI-S logic with width 1
-        VerilogParameter("axis_mock_slave_module_tid", "input", "logic [3:0]"), # Port 1: Input AXI-S logic with width 4
-        VerilogParameter("axis_mock_unknown_module_tunknown", "input", "logic [511:0]") # Port 2: Input unknown AXI-S logic with width 512
+        VerilogParameter("axis_mock_stream_master_module_tstrb", "output"), # Port 0: Master AXI-S logic with width 1
+        VerilogParameter("axis_mock_stream_slave_module_tid", "input", "logic [3:0]"), # Port 1: Slave AXI-S logic with width 4
+        VerilogParameter("axis_mock_stream_unknown_module_tunknown", "input", "logic [511:0]"), # Port 2: Unknown AXI-S logic with width 512
+        VerilogParameter("aximm_mock_memmap_master_module_arvalid", "output"), # Port 3: Master AXI-MM logic with width 1
+        VerilogParameter("aximm_mock_memmap_slave_module_awvalid", "input"), # Port 4: Slave AXI-MM logic with width 1
     ])
 
 mock_mixed_module_axis_roles = {
-    "mock_master_module": "master",
-    "mock_slave_module": "slave"
+    "mock_stream_master_module": "master",
+    "mock_stream_slave_module": "slave"
+}
+
+mock_mixed_module_aximm_roles = {
+    "mock_memmap_master_module": "master",
+    "mock_memmap_slave_module": "slave"
 }
 
 mock_generate_module = VerilogModule("mock_generate_module", [
-        VerilogParameter("axis_mock_generate_module_0_tdata", "input", "logic [`DEF1:`DEF2]"), # Port 0: Input AXI-S logic with unknown width
-        VerilogParameter("axis_mock_generate_module_1_tdata", "output", "logic [`DEF1:`DEF2]"), # Port 1: Output AXI-S logic with unknown width
+        VerilogParameter("axis_mock_generate_module_0_tdata", "input", "logic [`DEF1:`DEF2]"), # Port 0: Slave AXI-S logic with unknown width
+        VerilogParameter("axis_mock_generate_module_1_tdata", "output", "logic [`DEF1:`DEF2]"), # Port 1: Master AXI-S logic with unknown width
         VerilogParameter("axis_mock_generate_module_2_tunknown", "output", "logic [`DEF1:`DEF2]"), # Port 2: Output unknown AXI-S logic with unknown width
-        VerilogParameter("i64", "input", "[63:0]"), # Port 3: Input 64-bit bit vector
-        VerilogParameter("o1", "output"), # Port 4: Output 1-bit boolean
-        VerilogParameter("io32", "inout", "[31:0]"), # Port 5: Inout 32-bit bit-vector
-        VerilogParameter("iox", "inout", "[`DEF1:`DEF2]") # Port 6: Inout with unknown width bit-vector
+        VerilogParameter("aximm_mock_generate_module_0_wdata", "input", "logic [`DEF1:`DEF2]"), # Port 3: Slave AXI-MM logic with unknown width
+        VerilogParameter("aximm_mock_generate_module_1_wdata", "output", "logic [`DEF1:`DEF2]"), # Port 4: Master AXI-MM logic with unknown width
+        VerilogParameter("i64", "input", "[63:0]"), # Port 5: Input 64-bit bit vector
+        VerilogParameter("o1", "output"), # Port 6: Output 1-bit boolean
+        VerilogParameter("io32", "inout", "[31:0]"), # Port 7: Inout 32-bit bit-vector
+        VerilogParameter("iox", "inout", "[`DEF1:`DEF2]") # Port 8: Inout with unknown width bit-vector
     ])
 
 mock_generate_module_port_mappings = [
@@ -39,6 +47,8 @@ mock_generate_module_port_mappings = [
     call("axis slave axis_mock_generate_module_0_tdata axis_mock_generate_module_0 tdata\n"),
     call("axis master axis_mock_generate_module_1_tdata axis_mock_generate_module_1 tdata\n"),
     call("output ? axis_mock_generate_module_2_tunknown axis_mock_generate_module_2_tunknown\n"),
+    call("aximm slave aximm_mock_generate_module_0_wdata aximm_mock_generate_module_0 wdata\n"),
+    call("aximm master aximm_mock_generate_module_1_wdata aximm_mock_generate_module_1 wdata\n"),
     call("input 64 i64 i64\n"),
     call("output 1 o1 o1\n"),
     call("inout 32 io32 io32\n"),
@@ -46,6 +56,11 @@ mock_generate_module_port_mappings = [
 ]
 
 mock_generate_module_axis_roles = {
+    "mock_generate_module_0": "slave",
+    "mock_generate_module_1": "master",
+}
+
+mock_generate_module_aximm_roles = {
     "mock_generate_module_0": "slave",
     "mock_generate_module_1": "master",
 }
@@ -65,21 +80,34 @@ class GeneratePortMappingsTest(unittest.TestCase):
         self.assertEqual(gpm.determine_port_width(mock_master_module.ports[3]), 2)
         self.assertEqual(gpm.determine_port_width(mock_master_module.ports[4]), 1)
         self.assertEqual(gpm.determine_port_width(mock_master_module.ports[5]), "?")
-        self.assertEqual(gpm.determine_port_width(mock_master_module.ports[6]), 1)
     
     def test_is_axis_port(self):
         """
         Tests the is_axis_port function for correct output
         """
-        self.assertFalse(gpm.is_axis_port(mock_master_module.ports[0]))
-        self.assertTrue(gpm.is_axis_port(mock_master_module.ports[5]))
+        self.assertTrue(gpm.is_axis_port(mock_mixed_module.ports[0])) # Valid AXI-S port
+        self.assertTrue(gpm.is_axis_port(mock_mixed_module.ports[2])) # Unknown AXI-S port still is an AXI-S port with no role
+        self.assertFalse(gpm.is_axis_port(mock_mixed_module.ports[3])) # AXI-MM port is not AXI-S
+
+    def test_is_aximm_port(self):
+        """
+        Tests the is_aximm_port function for correct output
+        """
+        self.assertTrue(gpm.is_aximm_port(mock_mixed_module.ports[3])) # Valid AXI-MM port
+        self.assertFalse(gpm.is_aximm_port(mock_mixed_module.ports[0])) # AXI-S port is not AXI-MM
 
     def test_is_axis_role_found(self):
         """
         Tests the is_axis_port function for correct output
         """
-        self.assertTrue(gpm.is_axis_role_found(mock_mixed_module_axis_roles, mock_mixed_module.ports[0]))
-        self.assertFalse(gpm.is_axis_role_found(mock_mixed_module_axis_roles, mock_mixed_module.ports[2]))
+        self.assertTrue(gpm.is_axis_role_found(mock_mixed_module_axis_roles, mock_mixed_module.ports[0])) # AXI-S Master Port
+        self.assertFalse(gpm.is_axis_role_found(mock_mixed_module_axis_roles, mock_mixed_module.ports[2])) # Unknown AXI-S port
+
+    def test_is_aximm_role_found(self):
+        """
+        Tests the is_aximm_port function for correct output
+        """
+        self.assertTrue(gpm.is_aximm_role_found(mock_mixed_module_aximm_roles, mock_mixed_module.ports[3])) # AXI-MM Master Port
 
     def test_determine_axis_roles(self):
         """
@@ -87,13 +115,29 @@ class GeneratePortMappingsTest(unittest.TestCase):
         """
         mixed_roles = gpm.determine_axis_roles(mock_mixed_module)
         # test a: slave port is detected correctly
-        self.assertIn("mock_slave_module", mixed_roles)
-        self.assertEqual(mixed_roles["mock_slave_module"], "slave")
+        self.assertIn("mock_stream_slave_module", mixed_roles)
+        self.assertEqual(mixed_roles["mock_stream_slave_module"], "slave")
         # test b: master port is detected correctly
-        self.assertIn("mock_master_module", mixed_roles)
-        self.assertEqual(mixed_roles["mock_master_module"], "master")
+        self.assertIn("mock_stream_master_module", mixed_roles)
+        self.assertEqual(mixed_roles["mock_stream_master_module"], "master")
         # test c: unknown AXIS port is not detected
-        self.assertNotIn("mock_unknown_module", mixed_roles)
+        self.assertNotIn("mock_stream_unknown_module", mixed_roles)
+        # test d: master AXI-MM port is not detected
+        self.assertNotIn("mock_memmap_master_module", mixed_roles)
+
+    def test_determine_aximm_roles(self):
+        """
+        Tests the determine_aximm_roles function for correct output
+        """
+        mixed_roles = gpm.determine_aximm_roles(mock_mixed_module)
+        # test a: slave port is detected correctly
+        self.assertIn("mock_memmap_slave_module", mixed_roles)
+        self.assertEqual(mixed_roles["mock_memmap_slave_module"], "slave")
+        # test b: master port is detected correctly
+        self.assertIn("mock_memmap_master_module", mixed_roles)
+        self.assertEqual(mixed_roles["mock_memmap_master_module"], "master")
+        # test d: master AXI-S port is not detected
+        self.assertNotIn("mock_stream_master_module", mixed_roles)
 
     def test_generate_port_mappings_for_module(self):
         """
@@ -101,7 +145,7 @@ class GeneratePortMappingsTest(unittest.TestCase):
         """
         mock_file = Mock()
         mock_file.write = Mock()
-        warnings = gpm.generate_port_mappings_for_module(mock_file, mock_generate_module, mock_generate_module_axis_roles)
+        warnings = gpm.generate_port_mappings_for_module(mock_file, mock_generate_module, mock_generate_module_axis_roles, mock_generate_module_aximm_roles)
 
         mock_file.write.assert_has_calls(mock_generate_module_port_mappings)
         self.assertTrue(warnings, "Warnings should be generated when there exists a value that cannot be inferred automatically.")

--- a/rad-sim/test/wrapper-scripts/test_generate_wrapper.py
+++ b/rad-sim/test/wrapper-scripts/test_generate_wrapper.py
@@ -15,16 +15,18 @@ class GenerateWrapperTest(unittest.TestCase):
         """
 
         mock_port_map_file = PROJECT_PATH + "/test/wrapper-scripts/mock_port.map"
-        (mappings, axis_roles) = gw.read_port_mappings(mock_port_map_file)
+        (mappings, axis_roles, aximm_roles) = gw.read_port_mappings(mock_port_map_file)
         self.assertEqual(len(mappings), 1, "There should only be one module in the port map file")
 
         moduleMappings = mappings["mock_module"]
-        self.assertEqual(len(moduleMappings), 5)
+        self.assertEqual(len(moduleMappings), 7)
         self.assertIn(("sc_in", "1", "i1", "i1"), moduleMappings)
         self.assertIn(("sc_inout", "64", "io64", "io64"), moduleMappings)
         self.assertIn(("sc_out", "32", "o32", "o32"), moduleMappings)
         self.assertIn(("axis", "master", "axis_mock_master_tdata", "axis_mock_master.tdata"), moduleMappings)
         self.assertIn(("axis", "slave", "axis_mock_slave_tdata", "axis_mock_slave.tdata"), moduleMappings)
+        self.assertIn(("aximm", "master", "aximm_mock_master_wdata", "aximm_mock_master.wdata"), moduleMappings)
+        self.assertIn(("aximm", "slave", "aximm_mock_slave_wdata", "aximm_mock_slave.wdata"), moduleMappings)
 
         moduleAxisRoles = axis_roles["mock_module"]
         self.assertEqual(len(moduleAxisRoles), 2)
@@ -32,6 +34,13 @@ class GenerateWrapperTest(unittest.TestCase):
         self.assertEqual(moduleAxisRoles["axis_mock_master"], "master")
         self.assertIn("axis_mock_slave", moduleAxisRoles)
         self.assertEqual(moduleAxisRoles["axis_mock_slave"], "slave")
+
+        moduleAximmRoles = aximm_roles["mock_module"]
+        self.assertEqual(len(moduleAximmRoles), 2)
+        self.assertIn("aximm_mock_master", moduleAximmRoles)
+        self.assertEqual(moduleAximmRoles["aximm_mock_master"], "master")
+        self.assertIn("aximm_mock_slave", moduleAximmRoles)
+        self.assertEqual(moduleAximmRoles["aximm_mock_slave"], "slave")
 
     def test_read_port_mappings_incomplete(self):
         """


### PR DESCRIPTION
Summary of Changes:
- Added support for AXI-MM RTL modules in the generate_port_mappings and generate_wrapper scripts
- New example design, rtl_aximm which tests this functionality.
- Unit tests for AXI-MM RTL functionality