### PR TITLE
Stress test senario

### DIFF
--- a/rad-sim/config.py
+++ b/rad-sim/config.py
@@ -6,6 +6,7 @@ import shutil
 from itertools import repeat
 from copy import deepcopy
 from math import ceil
+import argparse
 
 def parse_config_file(config_filename, booksim_params, radsim_header_params, radsim_knobs, cluster_knobs):
     with open(config_filename, 'r') as yaml_config:
@@ -23,7 +24,7 @@ def parse_config_file(config_filename, booksim_params, radsim_header_params, rad
                 for param, param_value in param.items():
                     print('         ' + param, param_value)
                     param_name = param_category + '_' + param
-                    invalid_param = True
+                    invalid_param = False
                     if param_name in booksim_params[config_counter]:
                         booksim_params[config_counter][param_name] = param_value
                         invalid_param = False
@@ -461,15 +462,18 @@ def find_num_configs(config_filename):
     return config_counter
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("designs", nargs='+', help="Unique design names to be included in the simulation")
+    parser.add_argument("-config", "--config", help="Path to the configuration file", required=False, default=None)
+    args = parser.parse_args()
     # Get design name from command line argument
     if len(sys.argv) < 2:
         print("Invalid arguments: python config.py <unique_design_name> <[optional] other_unique_design_names>")
         exit(1)
 
-    design_names = set() #No duplicating design include statements and cmake commands
-    for i in range(1, len(sys.argv)): #skip 0th argument (that is current program name)
-        design_names.add(sys.argv[i])
-        print(sys.argv[i])
+    design_names = set(args.designs) #use set to avoid duplicates
+    for design_name in design_names:
+        print(design_name)
 
     # Check if design directory exists
     for design_name in design_names:
@@ -478,7 +482,11 @@ if __name__ == "__main__":
             exit(1)
 
     # Point to YAML configuration file
-    config_filename = f"{os.getcwd()}/example-designs/{design_name}/config.yml"
+    
+    if args.config is not None:
+        config_filename = f"{os.getcwd()}/example-designs/{design_name}/{args.config}"
+    else:
+        config_filename = f"{os.getcwd()}/example-designs/{design_name}/config.yml"
     config_names = []
 
     # List default parameter values

--- a/rad-sim/example-designs/producer_consumer/CMakeLists.txt
+++ b/rad-sim/example-designs/producer_consumer/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.16)
+find_package(SystemCLanguage CONFIG REQUIRED)
+
+include_directories(
+  ./
+  modules
+  ../../sim
+  ../../sim/noc
+  ../../sim/noc/booksim
+  ../../sim/noc/booksim/networks
+  ../../sim/noc/booksim/routers
+)
+
+set(srcfiles
+  modules/sender.cpp
+  modules/receiver.cpp
+  producer_consumer_system.cpp
+  producer_consumer_top.cpp
+)
+
+set(hdrfiles
+  modules/sender.hpp
+  modules/receiver.hpp
+  producer_consumer_system.hpp
+  producer_consumer_top.hpp
+)
+
+add_compile_options(-Wall -Wextra -pedantic)
+
+add_library(producer_consumer STATIC ${srcfiles} ${hdrfiles})
+target_link_libraries(producer_consumer PUBLIC SystemC::systemc booksim noc)

--- a/rad-sim/example-designs/producer_consumer/config_equal_freq_NoC.yml
+++ b/rad-sim/example-designs/producer_consumer/config_equal_freq_NoC.yml
@@ -1,0 +1,42 @@
+config rad1:
+  design:
+    name: 'producer_consumer'
+    noc_placement: ['producer_consumer.place']
+    clk_periods: [5.0]
+
+noc:
+  type: ['2d']
+  num_nocs: 1
+  clk_period: [5.0]
+  payload_width: [166]
+  topology: ['mesh']
+  dim_x: [4]
+  dim_y: [4] 
+  routing_func: ['dim_order']
+  vcs: [5]
+  vc_buffer_size: [8]
+  output_buffer_size: [8]
+  num_packet_types: [5]
+  router_uarch: ['iq']
+  vc_allocator: ['islip']
+  sw_allocator:  ['islip']
+  credit_delay: [1]
+  routing_delay: [1]
+  vc_alloc_delay: [1]
+  sw_alloc_delay: [1]
+
+noc_adapters:
+  clk_period: [5]
+  fifo_size: [16]
+  obuff_size: [2]
+  in_arbiter: ['fixed_rr']
+  out_arbiter: ['priority_rr']
+  vc_mapping: ['direct']
+
+
+cluster:
+  sim_driver_period: 5.0
+  telemetry_log_verbosity: 2
+  telemetry_traces: []
+  num_rads: 1
+  cluster_configs: ['rad1']

--- a/rad-sim/example-designs/producer_consumer/config_equal_freq_adaptor.yml
+++ b/rad-sim/example-designs/producer_consumer/config_equal_freq_adaptor.yml
@@ -1,0 +1,42 @@
+config rad1:
+  design:
+    name: 'producer_consumer'
+    noc_placement: ['producer_consumer.place']
+    clk_periods: [5.0]
+
+noc:
+  type: ['2d']
+  num_nocs: 1
+  clk_period: [1.0]
+  payload_width: [166]
+  topology: ['mesh']
+  dim_x: [4]
+  dim_y: [4] 
+  routing_func: ['dim_order']
+  vcs: [5]
+  vc_buffer_size: [8]
+  output_buffer_size: [8]
+  num_packet_types: [5]
+  router_uarch: ['iq']
+  vc_allocator: ['islip']
+  sw_allocator:  ['islip']
+  credit_delay: [1]
+  routing_delay: [1]
+  vc_alloc_delay: [1]
+  sw_alloc_delay: [1]
+
+noc_adapters:
+  clk_period: [5]
+  fifo_size: [16]
+  obuff_size: [2]
+  in_arbiter: ['fixed_rr']
+  out_arbiter: ['priority_rr']
+  vc_mapping: ['direct']
+
+
+cluster:
+  sim_driver_period: 5.0
+  telemetry_log_verbosity: 2
+  telemetry_traces: []
+  num_rads: 1
+  cluster_configs: ['rad1']

--- a/rad-sim/example-designs/producer_consumer/config_normal.yml
+++ b/rad-sim/example-designs/producer_consumer/config_normal.yml
@@ -1,0 +1,43 @@
+config rad1:
+  design:
+    name: 'producer_consumer'
+    noc_placement: ['producer_consumer.place']
+    clk_periods: [5.0]
+    
+
+noc:
+  type: ['2d']
+  num_nocs: 1
+  clk_period: [1.0]
+  payload_width: [166]
+  topology: ['mesh']
+  dim_x: [4]
+  dim_y: [4] 
+  routing_func: ['dim_order']
+  vcs: [5]
+  vc_buffer_size: [8]
+  output_buffer_size: [8]
+  num_packet_types: [5]
+  router_uarch: ['iq']
+  vc_allocator: ['islip']
+  sw_allocator:  ['islip']
+  credit_delay: [1]
+  routing_delay: [1]
+  vc_alloc_delay: [1]
+  sw_alloc_delay: [1]
+
+noc_adapters:
+  clk_period: [1.25]
+  fifo_size: [16]
+  obuff_size: [2]
+  in_arbiter: ['fixed_rr']
+  out_arbiter: ['priority_rr']
+  vc_mapping: ['direct']
+
+
+cluster:
+  sim_driver_period: 5.0
+  telemetry_log_verbosity: 2
+  telemetry_traces: []
+  num_rads: 1
+  cluster_configs: ['rad1']

--- a/rad-sim/example-designs/producer_consumer/modules/receiver.cpp
+++ b/rad-sim/example-designs/producer_consumer/modules/receiver.cpp
@@ -1,0 +1,70 @@
+#include <receiver.hpp>
+
+receiver::receiver(const sc_module_name &name, RADSimDesignContext* radsim_design)
+      : RADSimModule(name, radsim_design) {
+    this->radsim_design = radsim_design;
+ 
+    sensitive << rst;
+
+    SC_CTHREAD(Tick, clk.pos());
+    reset_signal_is(rst, true); // Reset is active high
+
+    RegisterModuleInfo();
+    refFile.open("sender_output.txt");
+}
+
+receiver::~receiver() {
+    //check if any data is left in the reference file
+    std:string line;
+    if(std::getline(refFile, line)) {
+        std::cout << "Some data have not arrived!" << std::endl;
+        errorFlag = true;
+    }
+    if (errorFlag) {
+        std::cerr << "Error occurred during data reception!" << std::endl;
+    } else {
+        std::cout << "Data reception completed successfully!" << std::endl;
+    }
+    refFile.close();
+}
+
+void receiver::Tick() {
+    if (rst) {
+        axis_receiver_interface.tready.write(false);  
+    } else {
+        axis_receiver_interface.tready.write(true); // Ready to receive data
+    }
+    wait();
+    errorFlag = false;
+    while (true) {
+        if (axis_receiver_interface.tvalid.read() && axis_receiver_interface.tready.read()) {
+            unsigned int tdata = axis_receiver_interface.tdata.read().range(31, 0).to_uint();;
+            bool tlast = axis_receiver_interface.tlast.read();
+            std::cout << "Received Data: " << std::to_string(tdata) << ", Last: " << tlast << std::endl;
+            //compare with reference file
+            if (refFile.is_open()) {
+                std::string line;
+                if (std::getline(refFile, line)) {
+                    if (line != std::to_string(tdata)) {
+                        std::cout << "Data mismatch! Expected: " << line << ", Received: " << std::to_string(tdata) << std::endl;
+                        errorFlag = true;
+                    }
+                } else {
+                    std::cout << "No more lines in reference file." << std::endl;
+                    errorFlag = true;
+                }
+            } else {
+                std::cerr << "Reference file not open!" << std::endl;
+                errorFlag = true;
+            }
+            
+        }
+        wait();
+    }
+}
+
+
+void receiver::RegisterModuleInfo() {
+    std::string port_name = module_name + ".axis_receiver_interface";
+    RegisterAxisSlavePort(port_name, &axis_receiver_interface, 128, 0);
+}

--- a/rad-sim/example-designs/producer_consumer/modules/receiver.hpp
+++ b/rad-sim/example-designs/producer_consumer/modules/receiver.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <axis_interface.hpp>
+#include <design_context.hpp>
+#include <queue>
+#include <radsim_defines.hpp>
+#include <radsim_module.hpp>
+#include <string>
+#include <systemc.h>
+#include <vector>
+#include <radsim_utils.hpp>
+#include <tuple>
+#include <fstream>
+#include <iostream>
+
+class receiver: public RADSimModule {
+private:
+    std::ifstream refFile;
+    bool errorFlag;
+public:
+    RADSimDesignContext* radsim_design;
+    sc_in<bool> rst;    
+    // Interface to the NoC
+    axis_slave_port axis_receiver_interface;
+
+    receiver(const sc_module_name &name, RADSimDesignContext* radsim_design);
+    ~receiver();    
+    void Tick();   // Sequential logic process
+    SC_HAS_PROCESS(receiver);
+    void RegisterModuleInfo();
+};

--- a/rad-sim/example-designs/producer_consumer/modules/sender.cpp
+++ b/rad-sim/example-designs/producer_consumer/modules/sender.cpp
@@ -1,0 +1,104 @@
+#include <sender.hpp>
+
+sender::sender(const sc_module_name &name, RADSimDesignContext* radsim_design, int amount_to_send, int wait_cycles)
+      : RADSimModule(name, radsim_design) {
+    this->radsim_design = radsim_design;
+    this->amount_to_send = amount_to_send;
+    this->wait_cycles = wait_cycles;
+
+    SC_CTHREAD(Tick, clk.pos());
+    reset_signal_is(rst, true); // Reset is active high
+    
+    RegisterModuleInfo();
+    outfile.open("sender_output.txt");
+}
+
+sender::~sender() {
+    // Destructor does not need to do anything for this module
+    if (outfile.is_open()) {
+        outfile.close();
+    }
+}
+
+void sender::sendData(unsigned int data) {    
+    std::string src_port_name = module_name + ".axis_sender_interface";
+    std::string dst_port_name = "receiver_inst.axis_receiver_interface";
+    uint64_t dst_addr = radsim_design->GetPortDestinationID(dst_port_name);
+    uint64_t src_addr = radsim_design->GetPortDestinationID(src_port_name);
+    sc_bv<AXIS_DESTW> dest_id_concat;
+    DEST_REMOTE_NODE(dest_id_concat) = 0; // staying on same RAD
+    DEST_LOCAL_NODE(dest_id_concat) = dst_addr;
+    DEST_RAD(dest_id_concat) = radsim_design->rad_id;       
+
+    axis_sender_interface.tdest.write(dest_id_concat);
+    axis_sender_interface.tid.write(0);
+    axis_sender_interface.tstrb.write(0);
+    axis_sender_interface.tkeep.write(0);
+    axis_sender_interface.tuser.write(src_addr);
+    
+    if (amount_to_send > 1) {
+        axis_sender_interface.tlast.write(0); // Not the last data
+    } else {
+        axis_sender_interface.tlast.write(1); // Last data
+    }
+    
+    axis_sender_interface.tdata.write(data);
+}
+
+void sender::Tick() {
+    if(rst) {
+        axis_sender_interface.tvalid.write(false);  
+    }
+    wait();
+
+    int data_left = amount_to_send;
+    cout << "Sender started with amount to send: " << amount_to_send << endl;
+    unsigned int placeholderData = 1;
+    bool firstTransaction = true;
+    axis_sender_interface.tvalid.write(true);
+
+    while (data_left > 0) {    
+        
+        double sim_cycle = GetSimulationCycle(radsim_config.GetDoubleKnobShared("sim_driver_period"));
+        if(firstTransaction) {
+            sendData(placeholderData);
+            std::cout << "@cycle " << sim_cycle << " Sending first data: " << placeholderData << std::endl;
+            firstTransaction = false;
+            outfile << placeholderData << std::endl;
+            placeholderData += 1;
+            data_left--;                     
+        }
+        else if(axis_sender_interface.tready.read()) {            
+            sendData(placeholderData);
+            std::cout << "@cycle " << sim_cycle << " Sending data: " << placeholderData << std::endl;
+            outfile << placeholderData << std::endl;
+            placeholderData += 1;
+            data_left--;
+        }
+        wait();      
+        
+    }
+
+    //wait for final ready signal before turning off the valid signal
+    while(!axis_sender_interface.tready.read()) {
+        wait();
+    }
+    axis_sender_interface.tvalid.write(false); // No more data to send
+    int wait_start_cycle = GetSimulationCycle(radsim_config.GetDoubleKnobShared("sim_driver_period"));
+    int curr_cycle = wait_start_cycle;
+
+    while(curr_cycle < wait_start_cycle + wait_cycles) {
+        curr_cycle = GetSimulationCycle(radsim_config.GetDoubleKnobShared("sim_driver_period"));
+        wait();
+    }
+    this->radsim_design->set_rad_done();
+}
+
+
+void sender::RegisterModuleInfo() {
+    std::string port_name = module_name + ".axis_sender_interface";
+    RegisterAxisMasterPort(port_name, &axis_sender_interface, 128, 0);
+}
+
+
+

--- a/rad-sim/example-designs/producer_consumer/modules/sender.hpp
+++ b/rad-sim/example-designs/producer_consumer/modules/sender.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <axis_interface.hpp>
+#include <design_context.hpp>
+#include <radsim_defines.hpp>
+#include <radsim_module.hpp>
+#include <string>
+#include <systemc.h>
+#include <vector>
+#include <radsim_utils.hpp>
+#include <fstream>
+#include <iostream>
+
+class sender : public RADSimModule {
+private:
+    std::ofstream outfile;
+    int amount_to_send; 
+    int wait_cycles;        
+public:
+    RADSimDesignContext* radsim_design;
+    sc_in<bool> rst;    
+
+    // Interface to the NoC
+    axis_master_port axis_sender_interface;
+    
+    sender(const sc_module_name &name, RADSimDesignContext* radsim_design, int amount_to_send = 10, int wait_cycles = 50);
+    ~sender();    
+    
+    void sendData(unsigned int data);
+    void Tick();   // Sequential logic process
+    SC_HAS_PROCESS(sender);
+    void RegisterModuleInfo();
+};

--- a/rad-sim/example-designs/producer_consumer/producer_consumer.clks
+++ b/rad-sim/example-designs/producer_consumer/producer_consumer.clks
@@ -1,0 +1,2 @@
+sender_inst 0 0
+receiver_inst 0 0

--- a/rad-sim/example-designs/producer_consumer/producer_consumer.place
+++ b/rad-sim/example-designs/producer_consumer/producer_consumer.place
@@ -1,0 +1,2 @@
+sender_inst 0 0 axis
+receiver_inst 0 1 axis

--- a/rad-sim/example-designs/producer_consumer/producer_consumer_system.cpp
+++ b/rad-sim/example-designs/producer_consumer/producer_consumer_system.cpp
@@ -1,0 +1,15 @@
+#include <producer_consumer_system.hpp>
+
+producer_consumer_system::producer_consumer_system(const sc_module_name &name, sc_clock *driver_clk_sig, RADSimDesignContext* radsim_design) 
+    : sc_module(name) {
+
+  // Instantiate design top-level
+  dut_inst = new producer_consumer_top("dut", radsim_design);
+  dut_inst->rst(rst_sig);
+  this->design_dut_inst = dut_inst;
+}
+
+producer_consumer_system::~producer_consumer_system() {
+  delete dut_inst;
+  delete sysclk;
+}

--- a/rad-sim/example-designs/producer_consumer/producer_consumer_system.hpp
+++ b/rad-sim/example-designs/producer_consumer/producer_consumer_system.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <producer_consumer_top.hpp>
+#include <chrono>
+#include <vector>
+#include <design_system.hpp>
+
+class producer_consumer_system : public RADSimDesignSystem {
+public:
+  sc_signal<bool> rst_sig;
+  sc_clock *sysclk;
+  producer_consumer_top *dut_inst;
+
+  producer_consumer_system(const sc_module_name &name, sc_clock *driver_clk_sig, RADSimDesignContext* radsim_design);
+  ~producer_consumer_system();
+};
+

--- a/rad-sim/example-designs/producer_consumer/producer_consumer_top.cpp
+++ b/rad-sim/example-designs/producer_consumer/producer_consumer_top.cpp
@@ -1,0 +1,42 @@
+#include <producer_consumer_top.hpp>
+
+producer_consumer_top::producer_consumer_top(const sc_module_name &name, RADSimDesignContext* radsim_design)
+    : RADSimDesignTop(radsim_design) {
+
+  this->radsim_design = radsim_design;
+
+  std::string module_name_str;
+  char module_name[25];
+
+  module_name_str = "sender_inst";
+  std::strcpy(module_name, module_name_str.c_str());
+  int amount_to_send=5;
+
+  sender_inst = new sender(module_name, radsim_design, amount_to_send);
+  sender_inst->rst(rst);
+
+  module_name_str = "receiver_inst";
+  std::strcpy(module_name, module_name_str.c_str());
+
+  receiver_inst = new receiver(module_name, radsim_design);
+  receiver_inst->rst(rst);
+
+  this->connectPortalReset(&rst);
+  radsim_design->BuildDesignContext("producer_consumer.place", "producer_consumer.clks");
+  radsim_design->CreateSystemNoCs(rst);
+  radsim_design->ConnectModulesToNoC();
+  start_cycle = GetSimulationCycle(radsim_config.GetDoubleKnobShared("sim_driver_period"));
+}
+
+producer_consumer_top::~producer_consumer_top() {
+  end_cycle = GetSimulationCycle(radsim_config.GetDoubleKnobShared("sim_driver_period"));
+  NoCTransactionTelemetry::DumpStatsToFile("stats.csv");
+  NoCFlitTelemetry::DumpNoCFlitTracesToFile("flit_traces.csv");
+
+  std::vector<double> aggregate_bandwidths = NoCTransactionTelemetry::DumpTrafficFlows("traffic_flows", 
+    end_cycle - start_cycle, radsim_design->GetNodeModuleNames(), radsim_design->rad_id);
+  std::cout << "Aggregate NoC BW = " << aggregate_bandwidths[0] / 1000000000 << " Gbps" << std::endl;
+
+  delete sender_inst;
+  delete receiver_inst;
+}

--- a/rad-sim/example-designs/producer_consumer/producer_consumer_top.hpp
+++ b/rad-sim/example-designs/producer_consumer/producer_consumer_top.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <radsim_config.hpp>
+#include <sender.hpp>
+#include <receiver.hpp>
+#include <systemc.h>
+#include <vector>
+#include <design_top.hpp>
+#include <axis_interface.hpp>
+
+#include "radsim_config.hpp"
+
+class producer_consumer_top : public RADSimDesignTop {
+private:
+    sender *sender_inst;
+    receiver *receiver_inst;
+    RADSimDesignContext* radsim_design;
+    int start_cycle;
+    int end_cycle;
+public:
+    sc_in<bool> rst;
+    producer_consumer_top(const sc_module_name &name, RADSimDesignContext* radsim_design);
+    ~producer_consumer_top();
+};

--- a/rad-sim/example-designs/producer_consumer/replace_word.sh
+++ b/rad-sim/example-designs/producer_consumer/replace_word.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Root directory (defaults to current if not provided)
+ROOT_DIR="${1:-.}"
+
+# Step 1: Replace 'producer_consumer' with 'producer_consumer' in file contents
+find "$ROOT_DIR" -type f -print0 | while IFS= read -r -d '' file; do
+    # Only process text files
+    if grep -Iq . "$file"; then
+        sed -i 's/\btransmitter\b/producer_consumer/g' "$file"
+    fi
+done
+
+# Step 2: Rename files and directories that have 'producer_consumer' in the name
+# Process directories *after* files to avoid path issues
+find "$ROOT_DIR" -depth -name '*producer_consumer*' -print0 | while IFS= read -r -d '' path; do
+    new_path=$(echo "$path" | sed 's/producer_consumer/producer_consumer/g')
+    mv "$path" "$new_path"
+done
+

--- a/rad-sim/test/stress_test.sh
+++ b/rad-sim/test/stress_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+test_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd $test_path
+
+(cd ../; python config.py producer_consumer -config ../example-designs/producer_consumer/config_equal_freq_adaptor.yml)
+
+(cd ../build; make run)
+
+(cd ../; python config.py producer_consumer -config ../example-designs/producer_consumer/config_normal.yml)
+
+(cd ../build; make run)


### PR DESCRIPTION
Uses the consumer_producer design included in last PR to send a series of sequential number across the NoC network. currently we test for normal scenario(5.0 clk period for design, 1.25 for NoC and adaptor) and equal freq scenario(5.0 clk freq for all). 

New scenarios can be created with .yml files under the design directory for consumer_producer. a -config flag was added to config.py for accompanying easy swapping of .yml file

commands to run is included in stress_test.sh